### PR TITLE
enabled cross domain/proxied homeserver for custom homeserver users

### DIFF
--- a/lib/services/room_service.dart
+++ b/lib/services/room_service.dart
@@ -1,6 +1,7 @@
 import 'dart:ffi';
 
 import 'package:flutter_background_geolocation/flutter_background_geolocation.dart' as bg;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:matrix/matrix.dart';
 import 'package:grid_frontend/utilities/utils.dart';
 import 'package:grid_frontend/services/user_service.dart';
@@ -486,8 +487,12 @@ class RoomService {
       // Invite users to the room
       for (String id in userIds) {
         if (id != effectiveUserId) {
-          id = id.toLowerCase();
+          id = '@${id.toLowerCase()}';
           var fullUsername = '@' + id + ':' + client.homeserver.toString().replaceFirst('https://', '');
+          bool isCustomServer = isCustomHomeserver();
+          if (isCustomServer) {
+            fullUsername = id;
+          }
           await client.inviteUser(roomId, fullUsername);
         }
       }
@@ -500,6 +505,14 @@ class RoomService {
       return "Error";
     }
     return roomId;
+  }
+
+  bool isCustomHomeserver() {
+    final homeserver = getMyHomeserver().replaceFirst('https://', '');
+    if (homeserver == dotenv.env['HOMESERVER']) {
+      return false;
+    }
+    return true;
   }
 
   void getAndUpdateDisplayName() async {

--- a/lib/widgets/friend_request_modal.dart
+++ b/lib/widgets/friend_request_modal.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:random_avatar/random_avatar.dart';
 import 'package:grid_frontend/services/sync_manager.dart';
@@ -27,13 +28,24 @@ class FriendRequestModal extends StatefulWidget {
   _FriendRequestModalState createState() => _FriendRequestModalState();
 }
 
+
 class _FriendRequestModalState extends State<FriendRequestModal> {
   bool _isProcessing = false;
+
+
+  bool isCustomHomeserver() {
+    final homeserver = widget.roomService.getMyHomeserver().replaceFirst('https://', '');
+    if (homeserver == dotenv.env['HOMESERVER']) {
+      return false;
+    }
+    return true;
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final bool isCustomServer = isCustomHomeserver();
 
     return AlertDialog(
       content: Column(
@@ -46,9 +58,10 @@ class _FriendRequestModalState extends State<FriendRequestModal> {
           ),
           SizedBox(height: 20),
           Text(
-            widget.displayName,
+            '@${widget.displayName}',
             style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
           ),
+          isCustomServer ? Text(widget.userId) : Text(""),
           SizedBox(height: 10),
           Text(
             'Wants to connect with you. You will begin sharing locations once you accept.',


### PR DESCRIPTION
Can now add users from other homeservers if self hosting.

Example:

<img width="398" alt="image" src="https://github.com/user-attachments/assets/31428774-cea3-426b-a70d-7a61151e1b6d" />

Rather than historically only being able to add by localpart and assuming on same homeserver not behind a proxy. Needs f testing with federation but *should* work.