### PR TITLE
Fix: Disable Impeller to resolve black screen on some Android devices

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,11 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
+        <!-- Disable Impeller for compatibility with certain Android devices -->
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
+
         <!-- Foreground Service Configuration -->
         <service
             android:name=".LocationService"


### PR DESCRIPTION
- Added meta-data tag to disable Impeller rendering engine
- Fixes black screen issue on devices like Oppo Reno 3 Pro
- Falls back to Skia renderer for better compatibility