### PR TITLE
fix: fastlane deploy path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ fastlane/report.xml
 fastlane/README.md
 google-play-key.json
 fastlane/.env
+fastlane/keys/

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,7 +5,7 @@ def api_key
   app_store_connect_api_key(
     key_id: ENV["ASC_KEY_ID"],
     issuer_id: ENV["ASC_ISSUER_ID"],
-    key_filepath: File.join(Dir.pwd, ENV["ASC_KEY_FILE"] || "AuthKey.p8"),
+    key_filepath: File.join(Dir.pwd, ENV["ASC_KEY_FILE"] || "keys/AuthKey.p8"),
     in_house: false
   )
 end


### PR DESCRIPTION
## Changes

### Group Invitation Display Fix
- Fixed 3 bugs causing 'Invitation Sent' to not show in group member list
- Extended invite membership fallback to cover Group rooms (not just Direct)
- Fixed 'invited' vs 'invite' string mismatch in sync_manager and user_repository
- Switched to requestParticipants() for groups to include invited members
- Added Maestro E2E test (flow 14) verifying the fix

### Fastlane Deploy Fix
- Moved AuthKey.p8 to fastlane/keys/ (gitignored)
- Updated Fastfile to look in keys/ subdirectory
- Added fastlane/keys/ to .gitignore