### PR TITLE
fix(ci): copy fastlane secrets from runner before deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,12 @@ jobs:
           VERSION_CHECK_URL=https://version.mygrid.app
           EOF
 
+      - name: Set up Fastlane secrets
+        run: |
+          mkdir -p fastlane/keys
+          cp "$HOME/.fastlane-secrets/AuthKey.p8" fastlane/keys/AuthKey.p8
+          cp "$HOME/.fastlane-secrets/.env" fastlane/.env
+
       - name: Build & Upload iOS to TestFlight
         run: |
           export LC_ALL=en_US.UTF-8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,12 @@ jobs:
             build/app/outputs/
           retention-days: 30
 
+      - name: Set up Fastlane secrets
+        run: |
+          mkdir -p fastlane/keys
+          cp "$HOME/.fastlane-secrets/AuthKey.p8" fastlane/keys/AuthKey.p8
+          cp "$HOME/.fastlane-secrets/.env" fastlane/.env
+
       - name: Upload to TestFlight (iOS)
         if: success()
         run: |


### PR DESCRIPTION
AuthKey.p8 and fastlane/.env are gitignored, so they're missing in CI checkout. This adds a step to copy them from ~/.fastlane-secrets/ on the self-hosted runner.