### PR TITLE
fix(ci): pin Ruby 3.3 for CocoaPods compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,8 @@ jobs:
           mkdir -p fastlane/keys
           cp "$HOME/.fastlane-secrets/AuthKey.p8" fastlane/keys/AuthKey.p8
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
-
+          cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
+          cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
       - name: Build & Upload iOS to TestFlight
         run: |
           export LC_ALL=en_US.UTF-8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,8 @@ jobs:
           mkdir -p fastlane/keys
           cp "$HOME/.fastlane-secrets/AuthKey.p8" fastlane/keys/AuthKey.p8
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
-
+          cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
+          cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
       - name: Upload to TestFlight (iOS)
         if: success()
         run: |

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -53,7 +53,8 @@ jobs:
           mkdir -p fastlane/keys
           cp "$HOME/.fastlane-secrets/AuthKey.p8" fastlane/keys/AuthKey.p8
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
-
+          cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
+          cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
       - name: Build & Upload iOS to TestFlight
         run: |
           export LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Ruby 4.0 broke CocoaPods 1.16.2 due to encoding changes (`Encoding::CompatibilityError` in `unicode_normalize`). Pin to ruby@3.3 until CocoaPods ships a fix.