### PR TITLE
fix: auto-bump build number in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,29 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-bump build number
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          PUBSPEC="pubspec.yaml"
+          CURRENT=$(grep '^version:' "$PUBSPEC" | sed 's/version: *//')
+          VERSION_NAME="${CURRENT%%+*}"
+          BUILD_NUMBER="${CURRENT##*+}"
+          NEW_BUILD=$((BUILD_NUMBER + 1))
+          NEW_VERSION="${VERSION_NAME}+${NEW_BUILD}"
+          sed -i '' "s/^version: .*/version: ${NEW_VERSION}/" "$PUBSPEC"
+          echo "📦 Version bump: ${CURRENT} → ${NEW_VERSION}"
+          echo "BUILD_NUMBER=${NEW_BUILD}" >> $GITHUB_ENV
+          echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
+
+          # Commit and push the version bump
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$PUBSPEC"
+          git commit -m "chore: bump build number to ${NEW_BUILD} [skip ci]"
+          git push origin main
 
       - name: Create .env
         run: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,33 +15,11 @@ platform :ios do
   lane :beta do |options|
     api_key
 
-    # Read current pubspec version
+    # Version is already bumped by CI — just read it
     pubspec_path = File.join(Dir.pwd, "..", "pubspec.yaml")
     pubspec = File.read(pubspec_path)
     current_version = pubspec.match(/version:\s*(\S+)/)[1]
-    version_name, build_number = current_version.split("+")
-    
-    # Always increment build number
-    new_build = build_number.to_i + 1
-    
-    # Version bumps only on release builds, not regular beta/TestFlight uploads
-    # Pass version:1.2.0 explicitly OR release:true to auto-bump patch
-    if options[:version]
-      new_version = options[:version]
-    elsif options[:release]
-      parts = version_name.split(".")
-      parts[2] = parts[2].to_i + 1
-      new_version = parts.join(".")
-    else
-      new_version = version_name
-    end
-    
-    new_full = "#{new_version}+#{new_build}"
-    UI.message("📦 Bumping: #{current_version} → #{new_full}")
-    
-    # Write back to pubspec.yaml
-    pubspec.gsub!(/version:\s*\S+/, "version: #{new_full}")
-    File.write(pubspec_path, pubspec)
+    UI.message("📦 Building version: #{current_version}")
 
     # Build the Flutter IPA
     sh("cd #{File.join(Dir.pwd, '..')} && flutter build ipa --release --export-options-plist=ios/ExportOptions.plist")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: grid_frontend
 description: "Grid: Private Location Sharing"
 publish_to: 'none'
-version: 1.1.2+147
+version: 1.1.2+149
 environment:
   sdk: '>=3.3.3 <4.0.0'
 


### PR DESCRIPTION
## Problem
CI failed because version code 148 was already used on Play Store. The iOS Fastlane lane was bumping the build number locally but:
1. Never committing it back to the repo
2. Android lane didn't bump at all — it just read the stale pubspec
3. Build numbers drifted out of sync between repo and stores

## Fix
- **Auto-bump step** at the top of the deploy job — bumps build number in pubspec.yaml, commits & pushes back to main with `[skip ci]`
- **Removed duplicate bump** from iOS Fastlane lane — both platforms now use the same CI-bumped version
- **Bumped to 149** to clear the 148 conflict on Play Store

## How it works now
```
CI deploy job starts
  → reads pubspec (e.g. 1.1.2+149)
  → bumps to 1.1.2+150
  → commits back to main [skip ci]
  → iOS builds with +150
  → Android builds with +150
  → both upload successfully
```