### PR TITLE
fix: grant contents:write for CI deploy version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
     needs: [unit-tests, core-e2e-tests]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The deploy job needs `contents: write` permission so `github-actions[bot]` can push the auto-bumped build number back to main.

Without this, the `git push origin main` step fails with a 403 because the default GITHUB_TOKEN is read-only for contents.

Fixes: https://github.com/Rezivure/Grid-Mobile/actions/runs/22287082176/job/64467756568