### PR TITLE
fix: App Store release creates new version automatically

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,8 +47,17 @@ platform :ios do
   lane :release do
     api_key
 
+    # Read version from pubspec
+    pubspec_path = File.join(Dir.pwd, "..", "pubspec.yaml")
+    pubspec = File.read(pubspec_path)
+    current_version = pubspec.match(/version:\s*(\S+)/)[1]
+    version_name = current_version.split("+").first
+    build_number = current_version.split("+").last
+
     deliver(
       api_key: api_key,
+      app_version: version_name,
+      build_number: build_number,
       submit_for_review: true,
       automatic_release: false, # Manual release after review
       skip_binary_upload: true, # Use the TestFlight build


### PR DESCRIPTION
## What changed
`deliver` was failing with "Cannot find edit app store version" because 1.1.1 is live and no 1.1.2 draft existed. Now passes `app_version` and `build_number` so it creates the new version and picks the right TestFlight build.

## Changelog

- [x] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [ ] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
