### PR TITLE
fix: restore iOS Firebase config in CI and bump libre_location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,11 @@ jobs:
           cp "$HOME/.fastlane-secrets/AuthKey.p8" fastlane/keys/AuthKey.p8
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
           cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
+
+      - name: Restore Firebase iOS config
+        run: |
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+
       - name: Build & Upload iOS to TestFlight
         run: |
           export LC_ALL=en_US.UTF-8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,10 @@ jobs:
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
           cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
 
+      - name: Restore Firebase iOS config
+        run: |
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+
       - name: Build iOS
         run: |
           export PATH="/opt/homebrew/bin:$PATH"

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -55,6 +55,11 @@ jobs:
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
           cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
           cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
+
+      - name: Restore Firebase iOS config
+        run: |
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+
       - name: Build & Upload iOS to TestFlight
         run: |
           export LC_ALL=en_US.UTF-8

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ ios/build*
 
 # Firebase (contains API keys)
 android/app/google-services.json
+ios/GoogleService-Info.plist
 ios/Runner/GoogleService-Info.plist
 
 #Android Builds

--- a/changes/pr-191.md
+++ b/changes/pr-191.md
@@ -1,0 +1,1 @@
+[feat] Push notification support — APNs (iOS), FCM (Android), UnifiedPush/ntfy (degoogled Android) with iOS Notification Service Extension

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		9D642FEE4AD1523EE2F420E4 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35FD13841D8ED8CB53CA887F /* Pods_RunnerTests.framework */; };
 		CB1110F52E49234000D501E9 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB1110F42E49234000D501E9 /* StoreKit.framework */; };
-		CB71D5272F79FEB7005C8116 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CB71D5262F79FEB7005C8116 /* GoogleService-Info.plist */; };
-		CB71D5282F79FEB7005C8116 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CB71D5262F79FEB7005C8116 /* GoogleService-Info.plist */; };
 		ECFCA6962F79F39300386C62 /* GridNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = ECFCA68F2F79F39300386C62 /* GridNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		FD4B62FB5672D7B2CB70A143 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3737650B9FFA0C466F929C91 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
@@ -89,7 +87,6 @@
 		CB1110F42E49234000D501E9 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		CB2090EB2F70DA4600D7B87F /* RunnerProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerProfile.entitlements; sourceTree = "<group>"; };
 		CB701D6B2C75853F005A3751 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		CB71D5262F79FEB7005C8116 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E61F61E83E4CA900C31D3A83 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		ECFCA68F2F79F39300386C62 /* GridNotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = GridNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -168,7 +165,6 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
-				CB71D5262F79FEB7005C8116 /* GoogleService-Info.plist */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				ECFCA6902F79F39300386C62 /* GridNotificationService */,
@@ -343,7 +339,6 @@
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				CB71D5272F79FEB7005C8116 /* GoogleService-Info.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
@@ -353,7 +348,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB71D5282F79FEB7005C8116 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1075,10 +1075,10 @@ packages:
     dependency: "direct main"
     description:
       name: libre_location
-      sha256: "6c9ab3428fa5bf39425594a286a02a9cb40177e0f5d551f7e46d30669dcd0df8"
+      sha256: dcbeb990ca6dec6b2ca8d57846050287760f05488f4331cb1767657e91e1517b
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.1"
   lints:
     dependency: transitive
     description:
@@ -1131,10 +1131,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1856,26 +1856,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   timeago:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   flutter_bloc: ^8.1.6
   collection: ^1.18.0
   equatable: ^2.0.7
-  libre_location: ^0.1.0
+  libre_location: ^0.2.1
   hive: ^2.2.3
   qr_code_scanner_plus: ^2.0.6
   package_info_plus: ^8.1.2


### PR DESCRIPTION
## Summary
- restore `GoogleService-Info.plist` from runner-local secrets before iOS builds in CI
- remove the accidental Xcode reference to the wrong root-level Firebase plist path
- bump `libre_location` to `0.2.1` in Grid-Mobile

[x] `fix`
[ ] `feature`
[ ] `improvement`
[ ] `skip`

**Release note:** Fix CI/TestFlight iOS Firebase config handling and update libre_location to 0.2.1.