### PR TITLE
fix: restore Firebase plist to Xcode path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Restore Firebase iOS config
         run: |
-          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/GoogleService-Info.plist
 
       - name: Build & Upload iOS to TestFlight
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Restore Firebase iOS config
         run: |
-          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/GoogleService-Info.plist
 
       - name: Build iOS
         run: |

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Restore Firebase iOS config
         run: |
-          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/GoogleService-Info.plist
 
       - name: Build & Upload iOS to TestFlight
         run: |


### PR DESCRIPTION
## Summary
- copy GoogleService-Info.plist to the iOS path Xcode actually expects
- fix CI, release, and temporary test-deploy workflows

## Testing
- workflow path inspection against ios/Runner.xcodeproj references

- [x] `fix`
- [ ] `feature`
- [ ] `improvement`
- [ ] `skip`

**Release note:** Fix iOS CI builds by restoring the Firebase plist to the correct Xcode path.