### PR TITLE
fix: restore Firebase plist path for iOS CI/TestFlight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,11 @@ jobs:
           cp "$HOME/.fastlane-secrets/AuthKey.p8" fastlane/keys/AuthKey.p8
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
           cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
+
+      - name: Restore Firebase iOS config
+        run: |
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+
       - name: Build & Upload iOS to TestFlight
         run: |
           export LC_ALL=en_US.UTF-8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,10 @@ jobs:
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
           cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
 
+      - name: Restore Firebase iOS config
+        run: |
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+
       - name: Build iOS
         run: |
           export PATH="/opt/homebrew/bin:$PATH"

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -55,6 +55,11 @@ jobs:
           cp "$HOME/.fastlane-secrets/.env" fastlane/.env
           cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
           cp "$HOME/.fastlane-secrets/google-play-key.json" fastlane/google-play-key.json
+
+      - name: Restore Firebase iOS config
+        run: |
+          cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
+
       - name: Build & Upload iOS to TestFlight
         run: |
           export LC_ALL=en_US.UTF-8


### PR DESCRIPTION
## Summary
- fix the Xcode project to reference GoogleService-Info.plist from ios/Runner/
- restore the Firebase plist in CI to ios/Runner/GoogleService-Info.plist
- fix TestFlight/release workflows failing during iOS archive

## Why
Main is failing before TestFlight upload with:
- Build input file cannot be found: ios/GoogleService-Info.plist

The intended canonical location is ios/Runner/GoogleService-Info.plist, so this updates the project reference instead of preserving the stale root-level path.

## Changelog
- [x] `fix`
- [ ] `feature`
- [ ] `improvement`
- [ ] `skip`

**Release note:** Fix iOS Firebase plist path so main can archive and upload to TestFlight again.
