### PR TITLE
fix: stop duplicate Info.plist generation in notification extension

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -838,7 +838,7 @@
 				DEVELOPMENT_TEAM = 45NCU5QA4S;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = GridNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = GridNotificationService;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -883,7 +883,7 @@
 				DEVELOPMENT_TEAM = 45NCU5QA4S;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = GridNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = GridNotificationService;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -925,7 +925,7 @@
 				DEVELOPMENT_TEAM = 45NCU5QA4S;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = GridNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = GridNotificationService;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";


### PR DESCRIPTION
## Summary
- disable generated Info.plists for the `GridNotificationService` target
- keep the explicit `GridNotificationService/Info.plist`
- fix the iOS archive failure caused by duplicate `Info.plist` outputs

## Why
Archive is failing with:
- `Multiple commands produce ... GridNotificationService.appex/Info.plist`

The extension target was configured with both:
- `GENERATE_INFOPLIST_FILE = YES`
- `INFOPLIST_FILE = GridNotificationService/Info.plist`

That causes Xcode to generate and also copy an Info.plist for the same target output.

## Changelog
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:** Fix iOS archive failure caused by duplicate Info.plist generation in the notification extension target.
