### PR TITLE
ci: wipe DerivedData before iOS archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,13 @@ jobs:
         run: |
           cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
 
+      - name: Clean iOS build artifacts
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          flutter clean
+          rm -rf ~/Library/Developer/Xcode/DerivedData/Runner-*
+          rm -rf ios/Pods ios/Podfile.lock ios/.symlinks ios/build
+
       - name: Build & Upload iOS to TestFlight
         run: |
           export LC_ALL=en_US.UTF-8

--- a/changes/pr-202.md
+++ b/changes/pr-202.md
@@ -1,0 +1,1 @@
+[fix] Fixed a CI-side issue that prevented new builds from reaching TestFlight and Play Store internal.


### PR DESCRIPTION
## Summary
- After PR #201's pbxproj fix (flipping `GENERATE_INFOPLIST_FILE` to `NO` on the notification extension), the main-branch deploy still failed with `Multiple commands produce GridNotificationService.appex/Info.plist`.
- Root cause on the self-hosted runner: Xcode's incremental build graph cached in `~/Library/Developer/Xcode/DerivedData/Runner-*` still contained both the auto-generated Info.plist task and the `INFOPLIST_FILE`-processed task from previous builds.
- This wipes Flutter, Pods, DerivedData, and `ios/build` before each archive so pbxproj changes take effect.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed a CI-side issue that prevented new builds from reaching TestFlight and Play Store internal.

## Test plan
- [ ] Merge and watch the post-merge Grid CI run — the Deploy to TestFlight & Play Store job should archive successfully and upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)