### PR TITLE
ci: auto-provision signing for notification extension

### DIFF
--- a/changes/pr-204.md
+++ b/changes/pr-204.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS signing so TestFlight and Play Store deploys succeed after push-notification extension was added.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,66 @@ platform :ios do
     current_version = pubspec.match(/version:\s*(\S+)/)[1]
     UI.message("📦 Building version: #{current_version}")
 
+    # Ensure App Store distribution profiles exist / are installed for
+    # both the main app and the notification service extension. sigh
+    # downloads existing profiles from App Store Connect (or creates
+    # them if missing) and installs them into
+    # ~/Library/MobileDevice/Provisioning Profiles/.
+    main_bundle_id = "app.mygrid.grid"
+    extension_bundle_id = "app.mygrid.grid.GridNotificationService"
+
+    sigh(
+      api_key: api_key,
+      app_identifier: main_bundle_id,
+      readonly: false,
+      force: false,
+      skip_install: false,
+    )
+    main_profile_name = lane_context[SharedValues::SIGH_NAME]
+
+    sigh(
+      api_key: api_key,
+      app_identifier: extension_bundle_id,
+      readonly: false,
+      force: false,
+      skip_install: false,
+    )
+    extension_profile_name = lane_context[SharedValues::SIGH_NAME]
+    UI.message("Using profiles: main=#{main_profile_name}, ext=#{extension_profile_name}")
+
+    # Regenerate ExportOptions.plist so export uses whatever profile
+    # names sigh resolved (the extension profile didn't exist before,
+    # and hardcoded names drift).
+    export_opts_path = File.join(Dir.pwd, "..", "ios", "ExportOptions.plist")
+    export_opts = <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+          <key>method</key>
+          <string>app-store</string>
+          <key>teamID</key>
+          <string>45NCU5QA4S</string>
+          <key>uploadBitcode</key>
+          <false/>
+          <key>uploadSymbols</key>
+          <true/>
+          <key>signingStyle</key>
+          <string>manual</string>
+          <key>signingCertificate</key>
+          <string>Apple Distribution</string>
+          <key>provisioningProfiles</key>
+          <dict>
+              <key>#{main_bundle_id}</key>
+              <string>#{main_profile_name}</string>
+              <key>#{extension_bundle_id}</key>
+              <string>#{extension_profile_name}</string>
+          </dict>
+      </dict>
+      </plist>
+    PLIST
+    File.write(export_opts_path, export_opts)
+
     # Build the Flutter IPA (verbose so codesign errors surface in CI logs)
     sh("cd #{File.join(Dir.pwd, '..')} && flutter build ipa --release --verbose --export-options-plist=ios/ExportOptions.plist")
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,8 +21,8 @@ platform :ios do
     current_version = pubspec.match(/version:\s*(\S+)/)[1]
     UI.message("📦 Building version: #{current_version}")
 
-    # Build the Flutter IPA
-    sh("cd #{File.join(Dir.pwd, '..')} && flutter build ipa --release --export-options-plist=ios/ExportOptions.plist")
+    # Build the Flutter IPA (verbose so codesign errors surface in CI logs)
+    sh("cd #{File.join(Dir.pwd, '..')} && flutter build ipa --release --verbose --export-options-plist=ios/ExportOptions.plist")
 
     # Upload to TestFlight
     upload_to_testflight(


### PR DESCRIPTION
## Summary
The main-deploy archive is now past the Info.plist duplicate issue (PR #203) but dies at `CodeSign` because the new GridNotificationService extension target has no provisioning profile.

- `ios/ExportOptions.plist` only mapped `app.mygrid.grid` → one profile; the extension bundle `app.mygrid.grid.GridNotificationService` had no mapping.
- CI only copied a single `.mobileprovision`, so xcodebuild couldn't sign the `.appex` during archive.

This uses `fastlane sigh` with the existing ASC API key to download (or create if missing) App Store distribution profiles for **both** bundle IDs and install them on the runner, then regenerates `ExportOptions.plist` with the resolved profile names.

Keeps `--verbose` on `flutter build ipa` so any residual signing problems surface immediately instead of being swallowed.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS signing so TestFlight and Play Store deploys succeed after push-notification extension was added.

## Test plan
- [ ] Post-merge Grid CI on main: `Deploy to TestFlight & Play Store` should archive, export, and upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)