### PR TITLE
fix: remove unsupported sigh param

### DIFF
--- a/changes/pr-205.md
+++ b/changes/pr-205.md
@@ -1,0 +1,1 @@
+[fix] Fixed Fastfile syntax so iOS deploys can proceed.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,6 @@ platform :ios do
       api_key: api_key,
       app_identifier: main_bundle_id,
       readonly: false,
-      force: false,
       skip_install: false,
     )
     main_profile_name = lane_context[SharedValues::SIGH_NAME]
@@ -42,7 +41,6 @@ platform :ios do
       api_key: api_key,
       app_identifier: extension_bundle_id,
       readonly: false,
-      force: false,
       skip_install: false,
     )
     extension_profile_name = lane_context[SharedValues::SIGH_NAME]


### PR DESCRIPTION
## Summary
PR #204 introduced `sigh` calls with `readonly: false, force: false` — fastlane rejects those two together ("Error resolving conflict between options: 'readonly' and 'force'"). Drop `force: false` (it's the default).

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed Fastfile syntax so iOS deploys can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)