### PR TITLE
fix: manual distribution signing for extension

### DIFF
--- a/changes/pr-206.md
+++ b/changes/pr-206.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS signing for the notification service extension so TestFlight builds can complete.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -871,8 +871,9 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = GridNotificationService/GridNotificationService.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				PROVISIONING_PROFILE_SPECIFIER = "app.mygrid.grid.GridNotificationService AppStore";
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 45NCU5QA4S;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;


### PR DESCRIPTION
## Summary
Real cause of the archive-step `errSecInternalComponent` uncovered via `--verbose`:
- xcodebuild auto-signing tried to sign the `.appex` with **Apple Development** cert `83AG2W9FMQ`
- That cert isn't in the CI temp keychain (which only holds the Apple Distribution cert imported via `BUILD_CERTIFICATE_BASE64`), and login.keychain isn't unlocked in CI
- codesign aborts with `errSecInternalComponent`

Switch the GridNotificationService **Release** config to manual signing with Apple Distribution + the sigh-installed App Store profile (`app.mygrid.grid.GridNotificationService AppStore`). The distribution cert is in the keychain, the profile is installed, archive should complete and export should proceed normally. Debug/Profile stay on Automatic so local dev builds are untouched.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS signing for the notification service extension so TestFlight builds can complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)