### PR TITLE
fix: manual distribution signing for main app Release

### DIFF
--- a/changes/pr-207.md
+++ b/changes/pr-207.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS signing for the main app so TestFlight archive builds complete.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -791,8 +791,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 45NCU5QA4S;
 				ENABLE_BITCODE = NO;
@@ -803,7 +803,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = app.mygrid.grid;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "app.mygrid.grid AppStore";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
## Summary
Main Runner Release config was still set to automatic signing with `Apple Development`, which Xcode picked for CI archives even though the self-hosted runner's keychain only holds an `Apple Distribution` key — Flutter's Flutter.framework re-sign step then failed with `errSecInternalComponent`.

Switch it to manual distribution signing: `CODE_SIGN_IDENTITY[sdk=iphoneos*] = "Apple Distribution"`, `CODE_SIGN_STYLE = Manual`, `PROVISIONING_PROFILE_SPECIFIER = "app.mygrid.grid AppStore"` (downloaded by sigh at build time — same pattern as the extension Release config from #206). Debug/Profile stay on Automatic so local dev builds are untouched.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS signing for the main app so TestFlight archive builds complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)