### PR TITLE
fix: align plugin NDK version with app to unblock Android bundle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,19 @@ rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
     project.evaluationDependsOn(':app')
+
+    // Keep plugin modules in sync with the app's ndkVersion. Without this,
+    // plugins that don't declare ndkVersion (e.g. webcrypto) fall back to
+    // AGP's default and clash with local.properties' ndk.dir, failing the
+    // release bundle with CXX1104.
+    afterEvaluate { subproject ->
+        if (subproject.plugins.hasPlugin("com.android.application")
+                || subproject.plugins.hasPlugin("com.android.library")) {
+            subproject.android {
+                ndkVersion "28.0.12433566"
+            }
+        }
+    }
 }
 
 tasks.register("clean", Delete) {

--- a/changes/pr-208.md
+++ b/changes/pr-208.md
@@ -1,0 +1,1 @@
+[fix] Fixed Android release bundle failing in CI due to plugin NDK version mismatch.


### PR DESCRIPTION
## Summary
The post-merge run of #207 got through iOS signing but failed `Build & Upload Android to Play Store Internal` with:

> `[CXX1104] NDK from ndk.dir at /Users/rezivure/Library/Android/sdk/ndk/28.0.12433566 had version [28.0.12433566] which disagrees with android.ndkVersion [26.1.10909125]` — while configuring `:webcrypto`.

`webcrypto`'s plugin `build.gradle` doesn't declare `ndkVersion`, so it falls back to AGP's default and clashes with `local.properties`' `ndk.dir`. Force every Android library/app subproject to inherit the app's `ndkVersion "28.0.12433566"` via a root-level `afterEvaluate` hook — the NDK that's actually installed on the runner (`~/Library/Android/sdk/ndk/28.0.12433566`).

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed Android release bundle failing in CI due to plugin NDK version mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)