### PR TITLE
fix: register Android ndkVersion hook before :app evaluation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,14 +29,14 @@ allprojects {
 
 
 rootProject.buildDir = '../build'
-subprojects {
-    project.buildDir = "${rootProject.buildDir}/${project.name}"
-    project.evaluationDependsOn(':app')
 
-    // Keep plugin modules in sync with the app's ndkVersion. Without this,
-    // plugins that don't declare ndkVersion (e.g. webcrypto) fall back to
-    // AGP's default and clash with local.properties' ndk.dir, failing the
-    // release bundle with CXX1104.
+// Keep plugin modules in sync with the app's ndkVersion. Without this,
+// plugins that don't declare ndkVersion (e.g. webcrypto) fall back to
+// AGP's default and clash with local.properties' ndk.dir, failing the
+// release bundle with CXX1104. Registered in its own block so the hook
+// is attached to every subproject before the evaluationDependsOn below
+// forces :app to evaluate.
+subprojects {
     afterEvaluate { subproject ->
         if (subproject.plugins.hasPlugin("com.android.application")
                 || subproject.plugins.hasPlugin("com.android.library")) {
@@ -45,6 +45,11 @@ subprojects {
             }
         }
     }
+}
+
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
 }
 
 tasks.register("clean", Delete) {

--- a/changes/pr-209.md
+++ b/changes/pr-209.md
@@ -1,0 +1,1 @@
+[fix] Fixed Android release bundle after NDK-version hook mis-ordering broke Gradle evaluation.


### PR DESCRIPTION
## Summary
The post-merge run of #208 failed with:

> `A problem occurred evaluating root project 'android'. > Cannot run Project.afterEvaluate(Closure) when the project is already evaluated.`

The `subprojects { ... evaluationDependsOn(':app') ... afterEvaluate { } }` closure tried to register the `afterEvaluate` hook on `:app` in the same iteration that had just asked Gradle to eagerly evaluate `:app`, so by the time the hook was registered the subproject was already past evaluation.

Split the two concerns into separate `subprojects { }` blocks so every subproject gets the ndkVersion-enforcement hook attached first, then the buildDir + `evaluationDependsOn(':app')` block runs.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed Android release bundle after NDK-version hook mis-ordering broke Gradle evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)