### PR TITLE
ci: restore Android google-services.json in deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,10 @@ jobs:
         run: |
           cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
 
+      - name: Restore Firebase Android config
+        run: |
+          cp "$HOME/.fastlane-secrets/google-services.json" android/app/google-services.json
+
       - name: Clean iOS build artifacts
         run: |
           export PATH="/opt/homebrew/bin:$PATH"

--- a/changes/pr-210.md
+++ b/changes/pr-210.md
@@ -1,0 +1,1 @@
+[fix] Fixed Android Play Store builds by restoring the Firebase google-services config in CI.


### PR DESCRIPTION
## Summary
The post-merge run of #209 got through the Android Gradle evaluation but failed `:app:processReleaseGoogleServices` with *File google-services.json is missing.*

`android/app/google-services.json` is gitignored (contains Firebase API keys), and the google_services plugin is required since push notifications landed in #193. The iOS Firebase plist has a matching restore step; add the same for Android so the file is copied from `\$HOME/.fastlane-secrets/google-services.json` into `android/app/` before the bundle build.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed Android Play Store builds by restoring the Firebase google-services config in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)