### PR TITLE
fix: drop legacy tink-android to unblock Android bundle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,6 +28,15 @@ def flutterVersionCode = localProperties.getProperty('flutter.versionCode', '1')
 def flutterVersionName = localProperties.getProperty('flutter.versionName', '1.0')
 
 
+// unifiedpush pulls com.google.crypto.tink:tink (unified lib) while
+// flutter_secure_storage's androidx.security:security-crypto:1.1.0-alpha06
+// still depends on the older tink-android — both contain the same classes
+// and fail checkReleaseDuplicateClasses. The unified tink supersedes
+// tink-android, so drop the old one from every configuration.
+configurations.all {
+    exclude group: 'com.google.crypto.tink', module: 'tink-android'
+}
+
 android {
     namespace "app.mygrid.grid"
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/changes/pr-211.md
+++ b/changes/pr-211.md
@@ -1,0 +1,1 @@
+[fix] Fixed Android release bundle by removing a duplicate Tink crypto library.


### PR DESCRIPTION
## Summary
The post-merge run of #210 got past Gradle evaluation and the Firebase plugin and made it all the way into the release bundle, then failed `:app:checkReleaseDuplicateClasses` with hundreds of duplicate `com.google.crypto.tink.*` classes.

`./gradlew app:dependencyInsight --dependency tink` traced the two artifacts to:
- `com.google.crypto.tink:tink:1.18.0` — pulled by `org.unifiedpush.android:connector:3.1.2` (via `:unifiedpush_android`)
- `com.google.crypto.tink:tink-android:1.8.0` — pulled by `androidx.security:security-crypto:1.1.0-alpha06` (via `:flutter_secure_storage`)

The unified `tink` library supersedes `tink-android` (same classes, same API). Exclude `tink-android` from every app configuration so only the unified artifact ships.

Verified locally with `flutter build appbundle --release` — bundle builds cleanly.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed Android release bundle by removing a duplicate Tink crypto library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)