### PR TITLE
ci: bump BUILD_NUMBER offset above Play Store versionCode 509

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,12 @@ jobs:
       - name: Set dynamic build number
         run: |
           export PATH="/opt/homebrew/bin:$PATH"
-          # Derive build number from CI run number (no git push needed)
-          BUILD_NUMBER=$(( ${{ github.run_number }} + 100 ))
+          # Derive build number from CI run number (no git push needed).
+          # Offset 600 keeps us above the highest versionCode already on
+          # any Play Store track (production was manually bumped to 509
+          # while CI deploys were broken). The bump is one-way — never
+          # lower the offset or Play Store will reject the upload.
+          BUILD_NUMBER=$(( ${{ github.run_number }} + 600 ))
           VERSION_NAME=$(grep '^version:' pubspec.yaml | sed 's/version: *//;s/+.*//')
           # Update pubspec.yaml for this build only (not committed)
           sed -i '' "s/^version: .*/version: ${VERSION_NAME}+${BUILD_NUMBER}/" pubspec.yaml

--- a/changes/pr-212.md
+++ b/changes/pr-212.md
@@ -1,0 +1,1 @@
+[fix] Fixed Play Store upload rejection by raising the CI build number above the existing production versionCode.


### PR DESCRIPTION
## Summary
The post-merge run of #211 got the iOS build to TestFlight and the Android bundle built cleanly — but `upload_to_play_store` failed with:

> `Google Api Error: Invalid request - You cannot rollout this release because it does not allow any existing users to upgrade to the newly added APKs.`

Reason: the dynamic build number formula is `github.run_number + 100`, producing ~220 today, while `google_play_track_version_codes` shows production and internal both at **509** (manually bumped during the months CI deploys were broken). Play Store can't accept an internal release with a lower versionCode than what's already on production — it would be a downgrade for internal testers.

Bump the CI offset from 100 → 600 so this run lands as ~720 and stays monotonically ahead. One-way bump — lowering it again will break the deploy.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed Play Store upload rejection by raising the CI build number above the existing production versionCode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)