### PR TITLE
fix: upload Android as Play Store draft to bypass rollout gates

### DIFF
--- a/changes/pr-213.md
+++ b/changes/pr-213.md
@@ -1,0 +1,1 @@
+[fix] Fixed Play Store upload by landing CI builds as drafts for manual promotion.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -132,9 +132,14 @@ platform :android do
   lane :beta do
     sh("cd #{File.join(Dir.pwd, '..')} && flutter build appbundle --release")
 
+    # Upload as draft: Play Console gates full rollout on manual
+    # declarations (exact-alarm usage, data safety, etc.) that can't
+    # be set via API. Draft uploads bypass rollout validation; the
+    # user promotes drafts to internal/production manually.
     upload_to_play_store(
       track: "internal",
       aab: File.join(Dir.pwd, "..", "build", "app", "outputs", "bundle", "release", "app-release.aab"),
+      release_status: "draft",
       skip_upload_metadata: true,
       skip_upload_images: true,
       skip_upload_screenshots: true


### PR DESCRIPTION
## Summary
The post-merge run of #212 cleared the versionCode check but then failed with:

> `Google Api Error: Invalid request - You must let us know whether your app uses any exact alarm permissions`

`libre_location` declares `SCHEDULE_EXACT_ALARM` / `USE_EXACT_ALARM`, and Play Console gates rollout on a **one-time declaration** that isn't exposed through the Developer API — same shape as data-safety and other policy forms.

Switch the upload to `release_status: "draft"`, so the AAB lands in Play Console for manual promotion. Keeps automation for build + upload; separates rollout (and any policy declarations) as a deliberate human step.

Long-term the user should declare exact-alarm usage in **Play Console → App content → Exact alarms** once; after that we can consider moving back to `completed` if desired, but `draft` is a safer default for any future rollout-gate additions.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed Play Store upload by landing CI builds as drafts for manual promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)