### PR TITLE
fix: set aps-environment=production for iOS Release archives

### DIFF
--- a/changes/pr-214.md
+++ b/changes/pr-214.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS push notifications on TestFlight and App Store builds.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -790,7 +790,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Runner/RunnerRelease.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 12;

--- a/ios/Runner/RunnerRelease.entitlements
+++ b/ios/Runner/RunnerRelease.entitlements
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:mygrid.app</string>
+		<string>webcredentials:mygrid.app?mode=developer</string>
+	</array>
+	<key>com.apple.developer.in-app-payments</key>
+	<array/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.app.mygrid.grid</string>
+	</array>
+	<key>aps-environment</key>
+	<string>production</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Sygnal server logs show every push to `app.mygrid.grid.ios` failing with `400 BadDeviceToken` — the APNs token the Grid app registered on TestFlight/App Store installs doesn't match the production APNs environment sygnal talks to.

Root cause in the project wiring:
- `ios/Runner/Runner.entitlements` has `aps-environment = development`
- `project.pbxproj` Release config pointed at `Runner.entitlements` → TestFlight archives registered sandbox tokens despite being production-signed.

Fix:
- New `ios/Runner/RunnerRelease.entitlements` (identical to `RunnerProfile.entitlements` but semantically named for the Release config) with `aps-environment = production`.
- Rewire the Release config to use it.
- Debug stays on the sandbox variant so local Xcode builds still work against APNs sandbox.

After merge, the next TestFlight install's APNs token will be a production token; sygnal should start delivering.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS push notifications on TestFlight and App Store builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)