### PR TITLE
fix: render iOS pushes + bridge creds to NSE + allowlist policy

### DIFF
--- a/changes/pr-216.md
+++ b/changes/pr-216.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS push notifications so invites, group joins, and friendship accepts actually surface as banners.

--- a/ios/GridNotificationService/EventClassifier.swift
+++ b/ios/GridNotificationService/EventClassifier.swift
@@ -1,104 +1,223 @@
 import UserNotifications
 
 /// Classifies Matrix events and decides how to format (or suppress) notifications.
+///
+/// Policy (product decision, 2026-04):
+///   The ONLY user-visible pushes are:
+///     1. Room invites (group or direct)
+///     2. Someone joining a GROUP room the user is already in
+///     3. Someone accepting a DIRECT-room invite the user sent (friendship accept)
+///
+///   Everything else — messages, location updates, avatar/map-icon announcements,
+///   typing, receipts, own actions — is suppressed (no banner, no sound, no badge).
 enum NotificationAction {
-    case suppress                           // Don't show notification (location, avatar, map icon events)
-    case showDefault                        // Show fallback "New activity in Grid"
-    case showMessage(title: String, body: String)  // Show formatted notification
-    case showCritical(title: String, body: String)  // Critical alert (SOS)
+    case suppress                                   // Do not show notification
+    case showMessage(title: String, body: String)   // Standard banner
 }
 
 final class EventClassifier {
-    
-    /// Classify based on a pre-cached event hint from the main app
+
+    /// Classify based on a pre-cached event hint from the main app.
+    ///
+    /// The hint path is deliberately conservative: the main app currently
+    /// writes hints for silent events (location / avatar / map icon) and
+    /// nothing else. Anything not explicitly allowlisted is suppressed.
     static func classify(hint: EventHint) -> NotificationAction {
         let type = hint.type.lowercased()
-        
-        // Suppress silent/background event types
-        if type == "m.location" { return .suppress }
-        if type.hasPrefix("m.avatar") { return .suppress }
-        if type.hasPrefix("m.map.icon") { return .suppress }
-        
-        // SOS / Emergency
-        if type == "sos" || type == "m.sos.alert" {
-            let title = "🆘 Emergency Alert"
-            let body = hint.summary ?? "SOS alert from a Grid member"
-            return .showCritical(title: title, body: body)
-        }
-        
-        // Geofence
-        if type == "geofence" || type.hasPrefix("m.geofence") {
-            let body = hint.summary ?? "Geofence event"
-            return .showMessage(title: "Grid", body: body)
-        }
-        
-        // Text message (future chat feature)
-        if type == "m.text" || type == "m.room.message" {
+
+        // Hints for invite / join state are not written today; if we ever
+        // start writing them, pass them straight through.
+        if type == "m.room.member.invite" {
             let sender = hint.senderName ?? "Someone"
-            let body = hint.summary ?? "sent a message"
-            return .showMessage(title: sender, body: body)
+            return .showMessage(title: "Grid", body: "\(sender) invited you")
         }
-        
-        return .showDefault
+        if type == "m.room.member.join.group" {
+            let sender = hint.senderName ?? "Someone"
+            let summary = hint.summary ?? "joined a group"
+            return .showMessage(title: "Grid", body: "\(sender) \(summary)")
+        }
+        if type == "m.room.member.join.direct" {
+            let sender = hint.senderName ?? "Someone"
+            return .showMessage(title: "Grid", body: "\(sender) accepted your invite")
+        }
+
+        // Every other hint — location, avatar, map icon, message, sos,
+        // geofence, unknown — is suppressed under the new policy.
+        return .suppress
     }
-    
-    /// Classify based on a fetched (unencrypted) Matrix event
-    static func classify(event: MatrixEvent) -> NotificationAction {
-        // If the event is encrypted and we can't decrypt, show fallback
-        if event.type == "m.room.encrypted" {
-            return .showDefault
+
+    /// Classify a fetched event **without any additional context**. This is
+    /// used as a fast path / fallback; it only allows the unambiguously
+    /// decidable cases (invite with matching state_key). For join-vs-direct
+    /// disambiguation see `classifyWithContext`.
+    static func classify(event: MatrixEvent, currentUserID: String?) -> NotificationAction {
+        guard event.type == "m.room.member" else {
+            // Messages, encrypted events, location updates, etc. — all suppressed.
+            return .suppress
         }
-        
-        // For unencrypted m.room.message, check msgtype
-        if event.type == "m.room.message", let msgtype = event.content?.msgtype {
-            switch msgtype {
-            case "m.location":
-                return .suppress
-            case _ where msgtype.hasPrefix("m.avatar"):
-                return .suppress
-            case _ where msgtype.hasPrefix("m.map.icon"):
-                return .suppress
-            case "m.text":
-                let body = event.content?.body ?? "New message"
-                return .showMessage(title: "Grid", body: body)
-            default:
-                return .showDefault
+        guard let membership = event.content?.membership else {
+            return .suppress
+        }
+
+        let senderDisplay = event.content?.displayname ?? event.sender ?? "Someone"
+
+        switch membership {
+        case "invite":
+            // Only notify on invites *to this user*, not invites to others.
+            if let me = currentUserID, event.stateKey == me {
+                return .showMessage(title: "Grid", body: "\(senderDisplay) invited you")
             }
+            return .suppress
+        case "join":
+            // Without room context we can't tell direct from group, or
+            // distinguish friendship-accept from fresh join. The async
+            // `classifyWithContext` path handles that; without context we
+            // suppress to avoid noisy own-joins / mid-session joins.
+            return .suppress
+        default:
+            // leave, ban, knock — never user-visible.
+            return .suppress
         }
-        
-        // Room member events, etc.
-        if event.type == "m.room.member" {
-            return .suppress  // Don't notify on join/leave
-        }
-        
-        return .showDefault
     }
-    
-    /// Apply the classification to a notification content object
+
+    /// Fully contextual classification. Fetches room state via [client] to
+    /// decide direct-vs-group and invite-accept-vs-fresh-join.
+    ///
+    /// Callers should always prefer this over [classify(event:currentUserID:)]
+    /// when they have a live `MatrixAPIClient`.
+    static func classifyWithContext(
+        event: MatrixEvent,
+        currentUserID: String?,
+        client: MatrixAPIClient
+    ) async -> NotificationAction {
+        guard event.type == "m.room.member",
+              let membership = event.content?.membership,
+              let roomID = event.roomId
+        else {
+            return .suppress
+        }
+
+        // Resolve the actor's display name. Prefer the event's content
+        // displayname (for join events it's the joiner; for invite events
+        // it's the invitee). For invites we actually want the *sender*'s
+        // name, so look them up if missing.
+        let actorUserID: String? = (membership == "invite") ? event.sender : event.stateKey
+        let actorDisplay = await resolveDisplayName(
+            event: event,
+            userID: actorUserID,
+            roomID: roomID,
+            client: client
+        )
+
+        switch membership {
+        case "invite":
+            // Only our own invites are user-visible.
+            guard let me = currentUserID, event.stateKey == me else {
+                return .suppress
+            }
+            // Differentiate group vs direct when the inviter flagged
+            // `is_direct: true` (Matrix convention for DM invites).
+            if event.content?.isDirect == true {
+                return .showMessage(
+                    title: "Grid",
+                    body: "\(actorDisplay) wants to share location with you"
+                )
+            }
+            if let roomName = await client.fetchRoomName(roomID: roomID), !roomName.isEmpty {
+                return .showMessage(
+                    title: "Grid",
+                    body: "\(actorDisplay) invited you to \(roomName)"
+                )
+            }
+            return .showMessage(title: "Grid", body: "\(actorDisplay) invited you")
+
+        case "join":
+            // Never notify on the current user's own joins.
+            if let me = currentUserID, event.stateKey == me {
+                return .suppress
+            }
+
+            // Direct-room join = friendship accept (only when the *previous*
+            // membership was an invite we sent; a fresh join into a direct
+            // room we didn't initiate isn't actionable and stays silent).
+            let directRooms: Set<String>
+            if let me = currentUserID {
+                directRooms = await client.fetchDirectRoomIDs(userID: me)
+            } else {
+                directRooms = []
+            }
+            let isDirect = directRooms.contains(roomID)
+            let prevMembership = event.unsigned?.prevContent?.membership
+
+            if isDirect {
+                if prevMembership == "invite" {
+                    return .showMessage(
+                        title: "Grid",
+                        body: "\(actorDisplay) accepted your invite"
+                    )
+                }
+                // Someone joining a DM room via some other path (re-join, etc.) —
+                // not an actionable event under the spec'd policy.
+                return .suppress
+            }
+
+            // Group room join: always notify, with the group name when known.
+            if let roomName = await client.fetchRoomName(roomID: roomID), !roomName.isEmpty {
+                return .showMessage(
+                    title: "Grid",
+                    body: "\(actorDisplay) joined \(roomName)"
+                )
+            }
+            return .showMessage(title: "Grid", body: "\(actorDisplay) joined a group")
+
+        default:
+            return .suppress
+        }
+    }
+
+    /// Apply the classification to a notification content object.
+    /// Returns `true` if the notification should be shown; `false` if the
+    /// caller should fall through to `suppressNotification(...)`.
     static func apply(action: NotificationAction, to content: UNMutableNotificationContent) -> Bool {
         switch action {
         case .suppress:
-            // Return false to indicate notification should be suppressed
             return false
-            
-        case .showDefault:
-            content.title = "Grid"
-            content.body = "New activity in Grid"
-            content.sound = .default
-            return true
-            
         case .showMessage(let title, let body):
             content.title = title
             content.body = body
             content.sound = .default
             return true
-            
-        case .showCritical(let title, let body):
-            content.title = title
-            content.body = body
-            content.sound = UNNotificationSound.defaultCritical
-            content.interruptionLevel = .critical
-            return true
         }
+    }
+
+    // MARK: - Helpers
+
+    private static func resolveDisplayName(
+        event: MatrixEvent,
+        userID: String?,
+        roomID: String,
+        client: MatrixAPIClient
+    ) async -> String {
+        // For a member event where the actor is also the state_key, the
+        // event's own content.displayname is the canonical value.
+        if event.stateKey == userID, let name = event.content?.displayname, !name.isEmpty {
+            return name
+        }
+        if let userID = userID {
+            if let member = try? await client.fetchRoomMember(roomID: roomID, userID: userID),
+               let name = member.displayname, !name.isEmpty {
+                return name
+            }
+            // Fall back to the Matrix ID localpart, which is still nicer
+            // than the bare MXID for end users.
+            return localpart(of: userID)
+        }
+        return "Someone"
+    }
+
+    private static func localpart(of userID: String) -> String {
+        // "@alice:example.com" → "alice"
+        guard userID.hasPrefix("@"), let colon = userID.firstIndex(of: ":") else { return userID }
+        return String(userID[userID.index(after: userID.startIndex)..<colon])
     }
 }

--- a/ios/GridNotificationService/MatrixAPIClient.swift
+++ b/ios/GridNotificationService/MatrixAPIClient.swift
@@ -6,43 +6,91 @@ final class MatrixAPIClient {
     private let homeserverURL: String
     private let accessToken: String
     private let session: URLSession
-    
+
     init(homeserverURL: String, accessToken: String) {
         self.homeserverURL = homeserverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         self.accessToken = accessToken
-        
+
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 15
         config.timeoutIntervalForResource = 25
         self.session = URLSession(configuration: config)
     }
-    
-    /// Fetch a single event by ID from a room
+
+    /// Fetch a single event by ID from a room. The CS API
+    /// `/rooms/{roomId}/event/{eventId}` endpoint returns the raw event,
+    /// including `unsigned.prev_content` for state events (we rely on that
+    /// to distinguish invite→join transitions).
     func fetchEvent(roomID: String, eventID: String) async throws -> MatrixEvent {
-        let encodedRoomID = roomID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? roomID
-        let encodedEventID = eventID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? eventID
-        
+        let encodedRoomID = encode(roomID)
+        let encodedEventID = encode(eventID)
+
         let urlString = "\(homeserverURL)/_matrix/client/v3/rooms/\(encodedRoomID)/event/\(encodedEventID)"
+        return try await getJSON(urlString: urlString, decode: MatrixEvent.self)
+    }
+
+    /// Fetch an `m.room.member` state event for a specific user in a room.
+    /// Used by the NSE to look up the sender's display name for invite/join
+    /// notifications without pulling the whole `/members` list.
+    func fetchRoomMember(roomID: String, userID: String) async throws -> MatrixEventContent {
+        let encodedRoomID = encode(roomID)
+        let encodedUserID = encode(userID)
+        let urlString =
+            "\(homeserverURL)/_matrix/client/v3/rooms/\(encodedRoomID)/state/m.room.member/\(encodedUserID)"
+        return try await getJSON(urlString: urlString, decode: MatrixEventContent.self)
+    }
+
+    /// Fetch the room's name (`m.room.name`). Returns nil on 404 / no name set
+    /// rather than throwing, because many rooms legitimately have no name and
+    /// we want the notification to degrade to a generic body, not error.
+    func fetchRoomName(roomID: String) async -> String? {
+        let encodedRoomID = encode(roomID)
+        let urlString =
+            "\(homeserverURL)/_matrix/client/v3/rooms/\(encodedRoomID)/state/m.room.name/"
+        struct NameState: Decodable { let name: String? }
+        return try? await getJSON(urlString: urlString, decode: NameState.self).name
+    }
+
+    /// Fetch the current user's `m.direct` account data and return the set of
+    /// room IDs that are flagged as direct (1:1) rooms.
+    ///
+    /// The endpoint returns `{ "<other_user_id>": ["!roomId:server", ...] }`,
+    /// so we flatten all values.
+    func fetchDirectRoomIDs(userID: String) async -> Set<String> {
+        let encodedUserID = encode(userID)
+        let urlString =
+            "\(homeserverURL)/_matrix/client/v3/user/\(encodedUserID)/account_data/m.direct"
+        guard let map = try? await getJSON(
+            urlString: urlString,
+            decode: [String: [String]].self
+        ) else {
+            return []
+        }
+        return Set(map.values.flatMap { $0 })
+    }
+
+    // MARK: - Internals
+
+    private func encode(_ s: String) -> String {
+        s.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? s
+    }
+
+    private func getJSON<T: Decodable>(urlString: String, decode: T.Type) async throws -> T {
         guard let url = URL(string: urlString) else {
             throw MatrixAPIError.invalidURL
         }
-        
         var request = URLRequest(url: url)
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        
         let (data, response) = try await session.data(for: request)
-        
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MatrixAPIError.invalidResponse
         }
-        
         guard httpResponse.statusCode == 200 else {
             throw MatrixAPIError.httpError(statusCode: httpResponse.statusCode)
         }
-        
-        return try JSONDecoder().decode(MatrixEvent.self, from: data)
+        return try JSONDecoder().decode(T.self, from: data)
     }
-    
+
     deinit {
         session.invalidateAndCancel()
     }
@@ -55,14 +103,29 @@ struct MatrixEvent: Decodable {
     let eventId: String?
     let sender: String?
     let roomId: String?
+    let stateKey: String?
     let content: MatrixEventContent?
-    
+    let unsigned: MatrixEventUnsigned?
+
     enum CodingKeys: String, CodingKey {
         case type
         case eventId = "event_id"
         case sender
         case roomId = "room_id"
+        case stateKey = "state_key"
         case content
+        case unsigned
+    }
+}
+
+struct MatrixEventUnsigned: Decodable {
+    /// For state events, the previous value of the state key (if any).
+    /// We use this to tell an accepted-invite join (`prev_content.membership
+    /// == "invite"`) from a fresh join.
+    let prevContent: MatrixEventContent?
+
+    enum CodingKeys: String, CodingKey {
+        case prevContent = "prev_content"
     }
 }
 
@@ -70,19 +133,25 @@ struct MatrixEventContent: Decodable {
     // For m.room.message
     let msgtype: String?
     let body: String?
-    
+
     // For m.room.encrypted
     let algorithm: String?
     let ciphertext: String?
     let senderKey: String?
     let sessionId: String?
     let deviceId: String?
-    
+
+    // For m.room.member
+    let membership: String?
+    let displayname: String?
+    let isDirect: Bool?
+
     enum CodingKeys: String, CodingKey {
-        case msgtype, body, algorithm, ciphertext
+        case msgtype, body, algorithm, ciphertext, membership, displayname
         case senderKey = "sender_key"
         case sessionId = "session_id"
         case deviceId = "device_id"
+        case isDirect = "is_direct"
     }
 }
 

--- a/ios/GridNotificationService/NotificationService.swift
+++ b/ios/GridNotificationService/NotificationService.swift
@@ -2,97 +2,119 @@ import UserNotifications
 
 /// Grid Notification Service Extension
 ///
-/// Intercepts push notifications to:
-/// 1. Classify the Matrix event type
-/// 2. Suppress silent events (location, avatar, map icons)
-/// 3. Format meaningful notifications for user-facing events
-/// 4. Fall back to "New activity in Grid" if decryption/classification fails
+/// Intercepts push notifications and, under the product's allowlist policy,
+/// only renders a user-visible banner for:
+///   1. Room invites (group or direct)
+///   2. Someone joining a group room the user is already in
+///   3. Someone accepting a direct-room invite the user sent (friendship accept)
+///
+/// Everything else — messages, location updates, avatar/map-icon events,
+/// typing, receipts, own-actions, unknown types, and all failure modes — is
+/// suppressed. "Suppressed" means: deliver empty content so iOS drops the
+/// notification without rendering anything.
+///
+/// The APNs pusher is registered with `format: event_id_only` and a
+/// `default_payload` of `aps.alert.body = " "`, so even in the worst case
+/// (NSE times out or OS never schedules us) the user sees no leaked content.
 class NotificationService: UNNotificationServiceExtension {
-    
+
     private var contentHandler: ((UNNotificationContent) -> Void)?
     private var bestAttemptContent: UNMutableNotificationContent?
-    
+
     override func didReceive(
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
         self.contentHandler = contentHandler
         self.bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
-        
+
         guard let bestAttemptContent = bestAttemptContent else {
-            contentHandler(request.content)
+            suppressNotification(contentHandler: contentHandler)
             return
         }
-        
+
         let userInfo = request.content.userInfo
         guard let eventID = userInfo["event_id"] as? String,
               let roomID = userInfo["room_id"] as? String else {
-            // No event info — show as-is
-            contentHandler(bestAttemptContent)
+            // No event info — can't classify, so suppress.
+            suppressNotification(contentHandler: contentHandler)
             return
         }
-        
+
         let storage = SharedStorage()
-        
-        // Step 1: Check if main app pre-cached a hint for this event
+        let currentUserID = storage.userID
+
+        // Step 1: fast path — use the main app's pre-cached event hint if any.
         if let hint = storage.eventHint(for: eventID) {
             let action = EventClassifier.classify(hint: hint)
             if EventClassifier.apply(action: action, to: bestAttemptContent) {
                 contentHandler(bestAttemptContent)
             } else {
-                // Suppress: deliver empty notification that iOS will discard
                 suppressNotification(contentHandler: contentHandler)
             }
             return
         }
-        
-        // Step 2: Try to fetch the event from homeserver
+
+        // Step 2: slow path — fetch the event from the homeserver and classify.
         guard storage.hasCredentials,
               let homeserver = storage.homeserverURL,
               let token = storage.accessToken else {
-            // No credentials — show fallback
-            bestAttemptContent.title = "Grid"
-            bestAttemptContent.body = "New activity in Grid"
-            contentHandler(bestAttemptContent)
+            // No credentials means the main app never bridged them into the
+            // App Group. Under the allowlist policy we suppress rather than
+            // show a generic "New activity" banner, which is just noise.
+            suppressNotification(contentHandler: contentHandler)
             return
         }
-        
+
         let client = MatrixAPIClient(homeserverURL: homeserver, accessToken: token)
-        
+
         Task {
             do {
                 let event = try await client.fetchEvent(roomID: roomID, eventID: eventID)
-                let action = EventClassifier.classify(event: event)
-                
+                let action = await EventClassifier.classifyWithContext(
+                    event: event,
+                    currentUserID: currentUserID,
+                    client: client
+                )
                 if EventClassifier.apply(action: action, to: bestAttemptContent) {
                     contentHandler(bestAttemptContent)
                 } else {
                     self.suppressNotification(contentHandler: contentHandler)
                 }
             } catch {
-                // Network error — show fallback
-                bestAttemptContent.title = "Grid"
-                bestAttemptContent.body = "New activity in Grid"
-                contentHandler(bestAttemptContent)
+                // Network / decode error — suppress. Showing a fallback here
+                // would both leak the fact that *some* activity happened and
+                // violate the allowlist policy.
+                self.suppressNotification(contentHandler: contentHandler)
             }
         }
     }
-    
+
     override func serviceExtensionTimeWillExpire() {
-        // Called just before the 30s limit. Deliver whatever we have.
-        if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
-            bestAttemptContent.title = "Grid"
-            bestAttemptContent.body = "New activity in Grid"
-            contentHandler(bestAttemptContent)
+        // We're about to be killed by iOS. We haven't finished classifying,
+        // so we don't know if this event is allowlisted. Suppress — iOS will
+        // fall back to the APNs default_payload, which itself is a silent
+        // placeholder (body = " ").
+        if let contentHandler = contentHandler {
+            suppressNotification(contentHandler: contentHandler)
         }
     }
-    
-    /// Suppress a notification by delivering an empty content with no alert.
-    /// iOS will not display a notification without a title/body.
+
+    /// Suppress a notification by delivering empty content.
+    ///
+    /// iOS suppresses a notification entirely when the delivered content has
+    /// no title and no body. We also zero out sound, badge, and interruption
+    /// level to be defensive about vendor-specific rendering.
     private func suppressNotification(contentHandler: @escaping (UNNotificationContent) -> Void) {
         let empty = UNMutableNotificationContent()
-        // Setting empty title+body effectively suppresses the visible notification.
-        // The badge/sound are also cleared.
+        empty.title = ""
+        empty.body = ""
+        empty.sound = nil
+        empty.badge = nil
+        if #available(iOS 15.0, *) {
+            empty.interruptionLevel = .passive
+            empty.relevanceScore = 0
+        }
         contentHandler(empty)
     }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -4,6 +4,10 @@ import FirebaseCore
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  /// App Group identifier shared with GridNotificationService.
+  /// Must match `SharedStorage.appGroupID` and the entitlements plists.
+  private static let appGroupID = "group.app.mygrid.grid"
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -19,5 +23,66 @@ import FirebaseCore
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+    // Wire the method channel the Flutter `AppGroupBridge` uses to mirror
+    // Matrix credentials into the App Group `UserDefaults` so the NSE can
+    // fetch events. Registered on the implicit engine so it attaches once,
+    // regardless of which Flutter entrypoint spawned us.
+    let channel = FlutterMethodChannel(
+      name: "app.mygrid.grid/app_group",
+      binaryMessenger: engineBridge.pluginRegistry.messenger()
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      guard let self = self else {
+        result(FlutterError(code: "DEAD", message: "AppDelegate gone", details: nil))
+        return
+      }
+      switch call.method {
+      case "writeMatrixCredentials":
+        self.writeMatrixCredentials(arguments: call.arguments, result: result)
+      case "clearMatrixCredentials":
+        self.clearMatrixCredentials(result: result)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  private func writeMatrixCredentials(arguments: Any?, result: FlutterResult) {
+    guard let args = arguments as? [String: Any?] else {
+      result(FlutterError(code: "BAD_ARGS", message: "Expected map", details: nil))
+      return
+    }
+    guard let defaults = UserDefaults(suiteName: AppDelegate.appGroupID) else {
+      result(FlutterError(code: "NO_SUITE", message: "App Group unavailable", details: nil))
+      return
+    }
+    // Only write keys that were actually provided; keep previous values
+    // otherwise so partial re-bridges don't wipe state.
+    if let token = args["access_token"] as? String {
+      defaults.set(token, forKey: "access_token")
+    }
+    if let homeserver = args["homeserver_url"] as? String {
+      defaults.set(homeserver, forKey: "homeserver_url")
+    }
+    if let userID = args["user_id"] as? String {
+      defaults.set(userID, forKey: "user_id")
+    }
+    if let deviceID = args["device_id"] as? String {
+      defaults.set(deviceID, forKey: "device_id")
+    }
+    result(nil)
+  }
+
+  private func clearMatrixCredentials(result: FlutterResult) {
+    guard let defaults = UserDefaults(suiteName: AppDelegate.appGroupID) else {
+      result(FlutterError(code: "NO_SUITE", message: "App Group unavailable", details: nil))
+      return
+    }
+    defaults.removeObject(forKey: "access_token")
+    defaults.removeObject(forKey: "homeserver_url")
+    defaults.removeObject(forKey: "user_id")
+    defaults.removeObject(forKey: "device_id")
+    result(nil)
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'package:grid_frontend/widgets/migration_modal.dart';
 import 'package:libre_location/libre_location.dart';
 import 'package:grid_frontend/services/debug_log_service.dart';
 import 'package:grid_frontend/services/push_notification_service.dart';
+import 'package:grid_frontend/services/push/app_group_bridge.dart';
 import 'package:grid_frontend/services/push/notification_channels.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -112,6 +113,9 @@ void main() async {
 
       // Register push notifications on session restore
       if (client.isLogged()) {
+        // Mirror credentials into the App Group before registering the
+        // pusher — the NSE needs them to fetch events when a push arrives.
+        await AppGroupBridge.writeMatrixCredentials(client);
         final pushService = PushNotificationService(client: client);
         await pushService.register();
       }

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -8,6 +8,7 @@ import 'package:grid_frontend/services/database_service.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:grid_frontend/utilities/utils.dart';
 import 'package:grid_frontend/services/push_notification_service.dart';
+import 'package:grid_frontend/services/push/app_group_bridge.dart';
 
 class AuthProvider with ChangeNotifier {
   bool _isLoggedIn = false;
@@ -66,6 +67,12 @@ class AuthProvider with ChangeNotifier {
       final homeserver = await client.homeserver;
       print("Logged in to: $homeserver");
 
+      // Mirror Matrix credentials into the iOS App Group so the
+      // GridNotificationService (NSE) can fetch events when a push arrives.
+      // Must happen before/alongside pusher registration so the first push
+      // after login finds credentials present.
+      await AppGroupBridge.writeMatrixCredentials(client);
+
       // Register push notifications
       try {
         final pushService = PushNotificationService(client: client);
@@ -88,6 +95,9 @@ class AuthProvider with ChangeNotifier {
     } catch (e) {
       print('Error unregistering push notifications: $e');
     }
+
+    // Clear App Group credentials so the NSE can't resurrect old tokens.
+    await AppGroupBridge.clearMatrixCredentials();
 
     _isLoggedIn = false;
     _token = null;

--- a/lib/services/push/app_group_bridge.dart
+++ b/lib/services/push/app_group_bridge.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:matrix/matrix.dart';
+
+/// Bridges Matrix credentials from the Flutter side into the iOS App Group
+/// `UserDefaults` so the GridNotificationService (NSE) can fetch events via
+/// `MatrixAPIClient` when a push arrives.
+///
+/// Without this, the NSE has no `access_token` / `homeserver_url` and can only
+/// fall back to the APNs `default_payload` — i.e. no user-visible notification.
+///
+/// On Android this is a no-op; the FCM background handler handles hint caching
+/// through a different path.
+class AppGroupBridge {
+  static const MethodChannel _channel =
+      MethodChannel('app.mygrid.grid/app_group');
+
+  /// Push the currently logged-in [Client]'s credentials into the App Group
+  /// shared defaults. Safe to call on non-iOS platforms (becomes a no-op).
+  static Future<void> writeMatrixCredentials(Client client) async {
+    if (!Platform.isIOS) return;
+    final accessToken = client.accessToken;
+    final homeserver = client.homeserver?.toString();
+    final userId = client.userID;
+    final deviceId = client.deviceID;
+
+    if (accessToken == null || homeserver == null) {
+      debugPrint('[AppGroupBridge] Skipping write: missing token/homeserver');
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod('writeMatrixCredentials', <String, String?>{
+        'access_token': accessToken,
+        'homeserver_url': homeserver,
+        'user_id': userId,
+        'device_id': deviceId,
+      });
+      debugPrint('[AppGroupBridge] Credentials mirrored to App Group');
+    } catch (e) {
+      debugPrint('[AppGroupBridge] Failed to mirror credentials: $e');
+    }
+  }
+
+  /// Clear credentials from the App Group shared defaults on logout.
+  static Future<void> clearMatrixCredentials() async {
+    if (!Platform.isIOS) return;
+    try {
+      await _channel.invokeMethod('clearMatrixCredentials');
+    } catch (e) {
+      debugPrint('[AppGroupBridge] Failed to clear credentials: $e');
+    }
+  }
+}

--- a/lib/services/push_notification_service.dart
+++ b/lib/services/push_notification_service.dart
@@ -129,6 +129,40 @@ class PushNotificationService {
   Future<void> _setPusher(PusherConfig config) async {
     final deviceName = await _deviceDisplayName();
 
+    // `default_payload` is a sygnal feature: it is merged into every APNs
+    // payload Sygnal generates. With `format: event_id_only` Sygnal by default
+    // emits a payload with **no `aps` dict**, which makes iOS drop the push
+    // silently (the NSE never even runs). We force `mutable-content: 1` so the
+    // NSE gets a chance to classify and either fill in or suppress the alert.
+    //
+    // The placeholder body is overwritten by the NSE on every push the user
+    // should see, and suppressed to empty for every other push. It is only
+    // visible if the NSE fails to run (hard OS-level failure) and iOS falls
+    // back to rendering the raw APNs payload — which we prefer to silence
+    // than to surface as a leak.
+    final defaultPayload = <String, dynamic>{
+      'aps': <String, dynamic>{
+        'mutable-content': 1,
+        'alert': <String, dynamic>{
+          'body': ' ',
+        },
+      },
+    };
+
+    final pusherData = PusherData(
+      url: config.dataUrl,
+      format: 'event_id_only',
+    );
+
+    // APNs-only knob. FCM / UnifiedPush ignore it; Sygnal's FCM path has its
+    // own default payload semantics we don't need to touch yet.
+    if (config.transport == PushTransport.apns) {
+      pusherData.additionalProperties = <String, Object?>{
+        ...pusherData.additionalProperties,
+        'default_payload': defaultPayload,
+      };
+    }
+
     final pusher = Pusher(
       appId: config.appId,
       pushkey: config.pushkey,
@@ -136,10 +170,7 @@ class PushNotificationService {
       deviceDisplayName: deviceName,
       lang: 'en',
       kind: 'http',
-      data: PusherData(
-        url: config.dataUrl,
-        format: 'event_id_only',
-      ),
+      data: pusherData,
     );
 
     final pushkeyPreview = config.pushkey.length > 20


### PR DESCRIPTION
## Summary
Three interlocking fixes so iOS push notifications actually render, and only for the right events.

**Today's state:** the server pipeline (device → Synapse → sygnal → APNs) returns 200. But no banner appears because:
- Sygnal's `event_id_only` produces an APNs payload with no `aps` dict, so iOS silently drops it (NSE never even runs).
- The NSE reads credentials from App Group UserDefaults the Flutter app never populates → always hits its "New activity in Grid" fallback instead of fetching event content.
- The classifier's suppress-vs-show logic wasn't aligned with the desired policy.

**After this PR:** banners fire for exactly three events:
1. Room invites (group + direct)
2. Someone joining a group you're in
3. Someone accepting your direct-room (friendship) invite

Everything else is silent.

## Changes

- **Pusher registration** (`lib/services/push_notification_service.dart`): APNs pushers now include a `default_payload` with `aps.mutable-content: 1` + a placeholder alert body, so iOS invokes the NSE.
- **Credential bridge** (new `lib/services/push/app_group_bridge.dart`, `ios/Runner/AppDelegate.swift`, `lib/providers/auth_provider.dart`, `lib/main.dart`): MethodChannel writes access_token / homeserver_url / user_id / device_id into App Group UserDefaults on login + session restore, clears on logout.
- **NSE policy allowlist** (`ios/GridNotificationService/EventClassifier.swift`, `MatrixAPIClient.swift`, `NotificationService.swift`): `NotificationAction` is now just `.suppress` / `.showMessage`. New fetchers for room member / name / m.direct. All fallback paths now suppress instead of rendering a fallback banner.

## Known limitation
Direct-vs-group detection relies on `is_direct` on invites and `m.direct` account data. If `RoomService` doesn't reliably set those, direct-room joins will render as group joins. Flagged for follow-up audit.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS push notifications so invites, group joins, and friendship accepts actually surface as banners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
