### PR TITLE
fix: AppDelegate Flutter messenger API

### DIFF
--- a/changes/pr-217.md
+++ b/changes/pr-217.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS TestFlight archive failure caused by incorrect Flutter messenger API usage.

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -26,13 +26,16 @@ import FirebaseCore
 
     // Wire the method channel the Flutter `AppGroupBridge` uses to mirror
     // Matrix credentials into the App Group `UserDefaults` so the NSE can
-    // fetch events. Registered on the implicit engine so it attaches once,
-    // regardless of which Flutter entrypoint spawned us.
+    // fetch events. FlutterPluginRegistry itself doesn't expose a messenger
+    // — get one via registrar(forPlugin:), which every plugin host supports.
+    guard let registrar = engineBridge.pluginRegistry
+      .registrar(forPlugin: "GridAppGroupBridge")
+    else { return }
     let channel = FlutterMethodChannel(
       name: "app.mygrid.grid/app_group",
-      binaryMessenger: engineBridge.pluginRegistry.messenger()
+      binaryMessenger: registrar.messenger()
     )
-    channel.setMethodCallHandler { [weak self] call, result in
+    channel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
       guard let self = self else {
         result(FlutterError(code: "DEAD", message: "AppDelegate gone", details: nil))
         return


### PR DESCRIPTION
## Summary
#216's AppDelegate.swift breaks the Release archive:

```
error: value of type 'any FlutterPluginRegistry' has no member 'messenger'
error: cannot infer type of closure parameter 'call'
error: cannot infer type of closure parameter 'result'
```

`FlutterPluginRegistry` (the protocol) doesn't expose `messenger()`. Get a messenger via `registrar(forPlugin:).messenger()` instead, and explicitly type the handler closure so Swift doesn't trip on the ObjC `FlutterResult` block.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS TestFlight archive failure caused by incorrect Flutter messenger API usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
