### PR TITLE
fix: NSE pass roomID to classifier so invites render

### DIFF
--- a/changes/pr-218.md
+++ b/changes/pr-218.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS invite banners rendering empty instead of showing X invited you.

--- a/ios/GridNotificationService/EventClassifier.swift
+++ b/ios/GridNotificationService/EventClassifier.swift
@@ -87,12 +87,16 @@ final class EventClassifier {
     /// when they have a live `MatrixAPIClient`.
     static func classifyWithContext(
         event: MatrixEvent,
+        roomID: String,
         currentUserID: String?,
         client: MatrixAPIClient
     ) async -> NotificationAction {
+        // `roomID` is passed explicitly because the CS API
+        // `/rooms/{roomId}/event/{eventId}` response often omits `room_id`
+        // from the body (it's already in the URL), so `event.roomId` is
+        // frequently nil even for valid events.
         guard event.type == "m.room.member",
-              let membership = event.content?.membership,
-              let roomID = event.roomId
+              let membership = event.content?.membership
         else {
             return .suppress
         }

--- a/ios/GridNotificationService/NotificationService.swift
+++ b/ios/GridNotificationService/NotificationService.swift
@@ -73,6 +73,7 @@ class NotificationService: UNNotificationServiceExtension {
                 let event = try await client.fetchEvent(roomID: roomID, eventID: eventID)
                 let action = await EventClassifier.classifyWithContext(
                     event: event,
+                    roomID: roomID,
                     currentUserID: currentUserID,
                     client: client
                 )


### PR DESCRIPTION
## Summary
Invites arrived on the phone as **empty banners** on the last build. The push pipeline works end-to-end — the NSE runs, fetches the event, and then `classifyWithContext` falls through to `.suppress` because of a guard on `event.roomId`.

The CS API `/rooms/{roomId}/event/{eventId}` endpoint often omits `room_id` from the response body (it's already in the URL), so `MatrixEvent.roomId` was reliably nil after `fetchEvent`. The guard at line 95 then failed and every event got suppressed.

Pass `roomID` explicitly from `NotificationService` (which has it from the push payload) rather than relying on the event body.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS invite banners rendering empty instead of showing "X invited you".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
