### PR TITLE
fix: NSE invite-state fallback when /event/{id} 404s

### DIFF
--- a/changes/pr-220.md
+++ b/changes/pr-220.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS invite push notifications rendering as empty banners.

--- a/ios/GridNotificationService/NotificationService.swift
+++ b/ios/GridNotificationService/NotificationService.swift
@@ -110,10 +110,40 @@ class NotificationService: UNNotificationServiceExtension {
                     self.suppressNotification(contentHandler: contentHandler)
                 }
             } catch {
-                os_log("suppress: fetchEvent threw %{public}@",
+                os_log("fetchEvent threw %{public}@ — trying member-state fallback",
                        log: nseLog, type: .error,
                        String(describing: error))
-                self.suppressNotification(contentHandler: contentHandler)
+
+                // Synapse rejects /rooms/{id}/event/{eid} for invitees who
+                // aren't members yet (typical 404). For invite pushes the
+                // current-member state still works because invitees own a
+                // m.room.member state event with membership=invite. Render
+                // the invite banner from that.
+                if let me = currentUserID,
+                   let member = try? await client.fetchRoomMember(
+                       roomID: roomID, userID: me),
+                   member.membership == "invite" {
+                    os_log("member fallback: invite confirmed", log: nseLog, type: .info)
+                    let inviterDisplay = member.displayname ?? "Someone"
+                    let isDirect = member.isDirect == true
+                    let body: String
+                    if isDirect {
+                        body = "\(inviterDisplay) wants to share location with you"
+                    } else if let name = await client.fetchRoomName(roomID: roomID),
+                              !name.isEmpty {
+                        body = "\(inviterDisplay) invited you to \(name)"
+                    } else {
+                        body = "\(inviterDisplay) invited you"
+                    }
+                    bestAttemptContent.title = "Grid"
+                    bestAttemptContent.body = body
+                    bestAttemptContent.sound = .default
+                    contentHandler(bestAttemptContent)
+                } else {
+                    os_log("member fallback: not an invite, suppress",
+                           log: nseLog, type: .info)
+                    self.suppressNotification(contentHandler: contentHandler)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Console.app log on the previous build with `os_log` showed:
```
suppress: fetchEvent threw httpError(statusCode: 404)
```

Synapse rejects `/_matrix/client/v3/rooms/{id}/event/{eid}` for invitees who aren't joined yet, so the NSE's fetch threw and the catch block suppressed → empty banner.

This matches what Element iOS and other Matrix clients do: on `fetchEvent` failure, fall back to `/_matrix/client/v3/rooms/{id}/state/m.room.member/{me}`, which **does** work for invitees and returns `membership=invite` + `displayname` + `is_direct`. From that we can render:

- direct invite → "*inviter* wants to share location with you"
- group invite → "*inviter* invited you to *room name*"
- otherwise → "*inviter* invited you"

If the fallback also fails or the membership isn't `invite`, suppress (allowlist policy preserved).

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS invite push notifications rendering as empty banners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
