### PR TITLE
fix: NSE generic invite banner when Synapse 403s state

### DIFF
--- a/changes/pr-221.md
+++ b/changes/pr-221.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS invite push notifications rendering as blank banners.

--- a/ios/GridNotificationService/NotificationService.swift
+++ b/ios/GridNotificationService/NotificationService.swift
@@ -157,13 +157,20 @@ class NotificationService: UNNotificationServiceExtension {
                     return
                 }
 
-                // Both endpoints inaccessible to this user. Treat as a
-                // generic invite — that's overwhelmingly the cause under
-                // the allowlist policy.
-                os_log("member fallback also failed — generic invite banner",
-                       log: nseLog, type: .info)
+                // Member-state inaccessible (Synapse 403s invitees on it).
+                // Room name is more permissive (stripped state) and is
+                // typically readable. Treat as a generic invite — that's
+                // overwhelmingly the cause under the allowlist policy.
+                let roomName = await client.fetchRoomName(roomID: roomID)
+                os_log("member fallback failed — generic invite banner, roomName=%{public}@",
+                       log: nseLog, type: .info,
+                       roomName ?? "<nil>")
                 bestAttemptContent.title = "Grid"
-                bestAttemptContent.body = "You have a new invite"
+                if let name = roomName, !name.isEmpty {
+                    bestAttemptContent.body = "You're invited to \(name)"
+                } else {
+                    bestAttemptContent.body = "You have a new invite"
+                }
                 bestAttemptContent.sound = .default
                 contentHandler(bestAttemptContent)
             }

--- a/ios/GridNotificationService/NotificationService.swift
+++ b/ios/GridNotificationService/NotificationService.swift
@@ -119,31 +119,53 @@ class NotificationService: UNNotificationServiceExtension {
                 // current-member state still works because invitees own a
                 // m.room.member state event with membership=invite. Render
                 // the invite banner from that.
+                // Best-effort: try to read self-member state for richer
+                // content. Synapse may 403 invitees here too, in which case
+                // we fall through to a generic invite banner — under the
+                // allowlisted policy a push the NSE can't decode is almost
+                // always an invite (the only event type where the user
+                // isn't yet a member of the room).
                 if let me = currentUserID,
                    let member = try? await client.fetchRoomMember(
-                       roomID: roomID, userID: me),
-                   member.membership == "invite" {
-                    os_log("member fallback: invite confirmed", log: nseLog, type: .info)
-                    let inviterDisplay = member.displayname ?? "Someone"
-                    let isDirect = member.isDirect == true
-                    let body: String
-                    if isDirect {
-                        body = "\(inviterDisplay) wants to share location with you"
-                    } else if let name = await client.fetchRoomName(roomID: roomID),
-                              !name.isEmpty {
-                        body = "\(inviterDisplay) invited you to \(name)"
-                    } else {
-                        body = "\(inviterDisplay) invited you"
+                       roomID: roomID, userID: me) {
+                    os_log("member fallback fetched: membership=%{public}@ isDirect=%{public}d",
+                           log: nseLog, type: .info,
+                           member.membership ?? "<nil>",
+                           (member.isDirect ?? false) ? 1 : 0)
+                    if member.membership == "invite" {
+                        let inviterDisplay = member.displayname ?? "Someone"
+                        let isDirect = member.isDirect == true
+                        let body: String
+                        if isDirect {
+                            body = "\(inviterDisplay) wants to share location with you"
+                        } else if let name = await client.fetchRoomName(roomID: roomID),
+                                  !name.isEmpty {
+                            body = "\(inviterDisplay) invited you to \(name)"
+                        } else {
+                            body = "\(inviterDisplay) invited you"
+                        }
+                        bestAttemptContent.title = "Grid"
+                        bestAttemptContent.body = body
+                        bestAttemptContent.sound = .default
+                        contentHandler(bestAttemptContent)
+                        return
                     }
-                    bestAttemptContent.title = "Grid"
-                    bestAttemptContent.body = body
-                    bestAttemptContent.sound = .default
-                    contentHandler(bestAttemptContent)
-                } else {
-                    os_log("member fallback: not an invite, suppress",
-                           log: nseLog, type: .info)
+                    // Member-state readable but not invite — we shouldn't
+                    // have been pushed for this; suppress.
+                    os_log("member fallback: not invite, suppress", log: nseLog, type: .info)
                     self.suppressNotification(contentHandler: contentHandler)
+                    return
                 }
+
+                // Both endpoints inaccessible to this user. Treat as a
+                // generic invite — that's overwhelmingly the cause under
+                // the allowlist policy.
+                os_log("member fallback also failed — generic invite banner",
+                       log: nseLog, type: .info)
+                bestAttemptContent.title = "Grid"
+                bestAttemptContent.body = "You have a new invite"
+                bestAttemptContent.sound = .default
+                contentHandler(bestAttemptContent)
             }
         }
     }

--- a/ios/GridNotificationService/NotificationService.swift
+++ b/ios/GridNotificationService/NotificationService.swift
@@ -158,16 +158,25 @@ class NotificationService: UNNotificationServiceExtension {
                 }
 
                 // Member-state inaccessible (Synapse 403s invitees on it).
-                // Room name is more permissive (stripped state) and is
-                // typically readable. Treat as a generic invite — that's
-                // overwhelmingly the cause under the allowlist policy.
+                // Fall back to parsing the room name like the Flutter app
+                // does — Grid encodes participants/group name into it:
+                //   "Grid:Direct:<user1>:<user2>"
+                //   "Grid:Group:<ts>:<groupName>:<creatorId>"
                 let roomName = await client.fetchRoomName(roomID: roomID)
-                os_log("member fallback failed — generic invite banner, roomName=%{public}@",
+                let parsed = parseGridRoomName(roomName, currentUser: currentUserID)
+                os_log("member fallback failed — parsed roomName=%{public}@ -> direct=%{public}@ group=%{public}@",
                        log: nseLog, type: .info,
-                       roomName ?? "<nil>")
+                       roomName ?? "<nil>",
+                       parsed.directOther ?? "<nil>",
+                       parsed.groupName ?? "<nil>")
+
                 bestAttemptContent.title = "Grid"
-                if let name = roomName, !name.isEmpty {
-                    bestAttemptContent.body = "You're invited to \(name)"
+                if let other = parsed.directOther {
+                    bestAttemptContent.body = "\(other) wants to share location with you"
+                } else if let group = parsed.groupName {
+                    bestAttemptContent.body = "You're invited to \(group)"
+                } else if let raw = roomName, !raw.isEmpty {
+                    bestAttemptContent.body = "You're invited to \(raw)"
                 } else {
                     bestAttemptContent.body = "You have a new invite"
                 }
@@ -185,6 +194,62 @@ class NotificationService: UNNotificationServiceExtension {
         if let contentHandler = contentHandler {
             suppressNotification(contentHandler: contentHandler)
         }
+    }
+
+    /// Parse a Grid-encoded room name. Mirrors the Flutter app's logic
+    /// in `lib/utilities/utils.dart`:
+    ///   - "Grid:Direct:<user1>:<user2>" → returns the *other* user's
+    ///     display-friendly name (MXID localpart)
+    ///   - "Grid:Group:<ts>:<groupName>:<creator>" → returns the group name
+    /// Falls through to (nil, nil) for any other format.
+    private func parseGridRoomName(
+        _ name: String?,
+        currentUser: String?
+    ) -> (directOther: String?, groupName: String?) {
+        guard let name = name, !name.isEmpty else { return (nil, nil) }
+
+        if name.hasPrefix("Grid:Direct:") {
+            let rest = String(name.dropFirst("Grid:Direct:".count))
+            // After the prefix we have "@u1:server:@u2:server" — splitting
+            // on `:` yields exactly 4 parts when both users are well-formed.
+            let parts = rest.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+            guard parts.count == 4 else { return (nil, nil) }
+            let user1 = "\(parts[0]):\(parts[1])"
+            let user2 = "\(parts[2]):\(parts[3])"
+            let otherMXID = (user1 == currentUser) ? user2 : user1
+            return (localpart(of: otherMXID), nil)
+        }
+
+        if name.hasPrefix("Grid:Group:") {
+            // "Grid:Group:<ts>:<groupName>:<creator MXID>"
+            // The creator MXID itself contains a `:` (e.g. @user:server),
+            // so we can't just split — but the first 3 fields are
+            // colon-free and the group name is everything between the 3rd
+            // colon and the next `:@` (start of creator MXID).
+            // Safer: strip prefix, find first `:`, that ends ts; find
+            // next `:`, between those is groupName-or-rest. Group names
+            // generally have no `:`, so this works.
+            let rest = String(name.dropFirst("Grid:Group:".count))
+            let parts = rest.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
+            // Expected: [ts, groupName, "@creator:server"]
+            guard parts.count >= 2 else { return (nil, nil) }
+            let group = parts[1].trimmingCharacters(in: .whitespaces)
+            return (nil, group.isEmpty ? nil : group)
+        }
+
+        return (nil, nil)
+    }
+
+    /// Strip the leading `@` and everything from `:` onward — i.e. turn
+    /// `@lily:matrix.mygrid.app` into `lily`. If the input doesn't match
+    /// MXID shape, return it unchanged so the caller still has *something*.
+    private func localpart(of mxid: String) -> String {
+        guard mxid.hasPrefix("@") else { return mxid }
+        let trimmed = mxid.dropFirst()
+        if let colon = trimmed.firstIndex(of: ":") {
+            return String(trimmed[..<colon])
+        }
+        return String(trimmed)
     }
 
     /// Suppress a notification by delivering empty content.


### PR DESCRIPTION
## Summary
NSE Console logs from a real push proved both API paths fail for invitees on this Synapse:

```
parsed eventID=$… roomID=!…
storage: hasCredentials=1 userID=@chandler:matrix.mygrid.app
fetching event...
fetchEvent threw httpError(statusCode: 404) — trying member-state fallback
Task <…> received response, status 403   ← fetchRoomMember
member fallback: not an invite, suppress
```

So `event/{eid}` 404s (expected) and `state/m.room.member/{me}` also 403s (Synapse history-visibility / member-acl in this server config doesn't grant invitees state read), and the NSE was suppressing → blank banner.

Stop suppressing in that path. Under the allowlist policy, a push the NSE can't decode is overwhelmingly an invite — it's the only event type where the user isn't a room member yet. Render `"Grid: You have a new invite"` as the floor. Group joins and friendship accepts still get rich banners because their room state IS readable (the user is a joined member).

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS invite push notifications rendering as blank banners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
