### PR TITLE
feat: push on member joins by overriding default rule

### DIFF
--- a/lib/services/push_notification_service.dart
+++ b/lib/services/push_notification_service.dart
@@ -68,6 +68,37 @@ class PushNotificationService {
     } catch (e, st) {
       debugPrint('[Push] Failed to register pusher: $e\n$st');
     }
+
+    // Override the default `.m.rule.member_event` so member-join events
+    // actually push. NSE filters out the user's own joins client-side
+    // (we can't express "state_key != self" as a server-side push rule
+    // condition).
+    await _ensureGroupJoinPushRule();
+  }
+
+  /// PUT an override push rule that fires on `m.room.member` events with
+  /// `membership == "join"`. Idempotent — safe to call on every login.
+  Future<void> _ensureGroupJoinPushRule() async {
+    try {
+      await client.request(
+        RequestType.PUT,
+        '/client/v3/pushrules/global/override/grid.member.join',
+        data: {
+          'actions': ['notify'],
+          'conditions': [
+            {'kind': 'event_match', 'key': 'type', 'pattern': 'm.room.member'},
+            {
+              'kind': 'event_match',
+              'key': 'content.membership',
+              'pattern': 'join',
+            },
+          ],
+        },
+      );
+      debugPrint('[Push] Override rule grid.member.join set');
+    } catch (e) {
+      debugPrint('[Push] Failed to set grid.member.join rule: $e');
+    }
   }
 
   /// Call on logout to remove this device's pusher from Synapse.


### PR DESCRIPTION
## Summary
"X joined GROUP" pushes never reached the phone because **Matrix's default `.m.rule.member_event` is `dont_notify`** — sygnal's logs confirmed Synapse never even attempted a push for the join event. Spec-default behavior, intentional in vanilla Matrix.

Override it on the user's account. On `PushNotificationService.register()`, idempotently PUT:

```
PUT /_matrix/client/v3/pushrules/global/override/grid.member.join
{
  "actions": ["notify"],
  "conditions": [
    { "kind": "event_match", "key": "type", "pattern": "m.room.member" },
    { "kind": "event_match", "key": "content.membership", "pattern": "join" }
  ]
}
```

Stored per-account on the homeserver. Survives reinstalls and applies across the user's devices.

The override fires on the user's own joins too — Matrix push rule conditions can't express "state_key != self". The NSE already suppresses self-joins client-side (`event.stateKey == currentUserID -> suppress`), so the only cost is one wasted NSE invocation per own-join event. Acceptable trade-off.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Push notifications now fire when someone joins a group you're in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
