### PR TITLE
fix: disable .m.rule.member_event so grid.member.join fires

### DIFF
--- a/changes/pr-223.md
+++ b/changes/pr-223.md
@@ -1,0 +1,1 @@
+[fix] Group join push notifications now actually fire.

--- a/lib/services/push_notification_service.dart
+++ b/lib/services/push_notification_service.dart
@@ -76,8 +76,18 @@ class PushNotificationService {
     await _ensureGroupJoinPushRule();
   }
 
-  /// PUT an override push rule that fires on `m.room.member` events with
-  /// `membership == "join"`. Idempotent — safe to call on every login.
+  /// Add an override rule that notifies on member-join events, AND
+  /// disable the spec-default `.m.rule.member_event` (which would
+  /// otherwise dont_notify all member events, including ours).
+  ///
+  /// Both calls are idempotent — safe to run on every login.
+  ///
+  /// Why disable the default instead of inserting before it: Synapse
+  /// rejects `?before=.m.rule.*` (default rules can't be used as a
+  /// before/after anchor in this version). Disabling the default
+  /// removes its dont_notify entirely; non-join member events
+  /// (leaves, profile changes) then match no override rule and
+  /// silently fall through, which matches the allowlist policy.
   Future<void> _ensureGroupJoinPushRule() async {
     try {
       await client.request(
@@ -98,6 +108,17 @@ class PushNotificationService {
       debugPrint('[Push] Override rule grid.member.join set');
     } catch (e) {
       debugPrint('[Push] Failed to set grid.member.join rule: $e');
+    }
+
+    try {
+      await client.request(
+        RequestType.PUT,
+        '/client/v3/pushrules/global/override/.m.rule.member_event/enabled',
+        data: {'enabled': false},
+      );
+      debugPrint('[Push] Disabled default .m.rule.member_event');
+    } catch (e) {
+      debugPrint('[Push] Failed to disable .m.rule.member_event: $e');
     }
   }
 


### PR DESCRIPTION
Synapse rejects `?before=.m.rule.*` (default rules can't be used as a before/after anchor on this version), so our override rule lands AFTER the default `.m.rule.member_event` and the default's `dont_notify` wins.

Disable the default instead. Non-join member events (leaves, profile changes) then match no override rule and silently fall through — same effect as before for those, while joins now reach `grid.member.join` and notify.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Group join push notifications now actually fire.