### PR TITLE
fix: push policy rework — silent suppress + synthetic join msgs

### DIFF
--- a/changes/pr-224.md
+++ b/changes/pr-224.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS push notifications: messages no longer leak as blank banners; group joins now actually push.

--- a/ios/GridNotificationService/EventClassifier.swift
+++ b/ios/GridNotificationService/EventClassifier.swift
@@ -51,6 +51,16 @@ final class EventClassifier {
     /// decidable cases (invite with matching state_key). For join-vs-direct
     /// disambiguation see `classifyWithContext`.
     static func classify(event: MatrixEvent, currentUserID: String?) -> NotificationAction {
+        // Synthetic Grid system message ("X joined room") posted by the
+        // joining user's app. Allowlisted because Matrix's default push
+        // rules don't notify on m.room.member joins and we can't easily
+        // override them server-side.
+        if event.type == "m.room.message",
+           event.content?.msgtype == "grid.member.join" {
+            let body = event.content?.body ?? "Someone joined a group"
+            return .showMessage(title: "Grid", body: body)
+        }
+
         guard event.type == "m.room.member" else {
             // Messages, encrypted events, location updates, etc. — all suppressed.
             return .suppress
@@ -91,6 +101,13 @@ final class EventClassifier {
         currentUserID: String?,
         client: MatrixAPIClient
     ) async -> NotificationAction {
+        // Synthetic Grid join message — render the body directly.
+        if event.type == "m.room.message",
+           event.content?.msgtype == "grid.member.join" {
+            let body = event.content?.body ?? "Someone joined a group"
+            return .showMessage(title: "Grid", body: body)
+        }
+
         // `roomID` is passed explicitly because the CS API
         // `/rooms/{roomId}/event/{eventId}` response often omits `room_id`
         // from the body (it's already in the URL), so `event.roomId` is

--- a/lib/services/push_notification_service.dart
+++ b/lib/services/push_notification_service.dart
@@ -69,56 +69,36 @@ class PushNotificationService {
       debugPrint('[Push] Failed to register pusher: $e\n$st');
     }
 
-    // Override the default `.m.rule.member_event` so member-join events
-    // actually push. NSE filters out the user's own joins client-side
-    // (we can't express "state_key != self" as a server-side push rule
-    // condition).
-    await _ensureGroupJoinPushRule();
+    // Reset any push rule overrides we previously installed when we
+    // tried to gate joins server-side. We now use synthetic
+    // `grid.member.join` messages instead, which push via the
+    // standard `.m.rule.message` rule and are gated by the NSE.
+    await _resetCustomPushRules();
   }
 
-  /// Add an override rule that notifies on member-join events, AND
-  /// disable the spec-default `.m.rule.member_event` (which would
-  /// otherwise dont_notify all member events, including ours).
-  ///
-  /// Both calls are idempotent — safe to run on every login.
-  ///
-  /// Why disable the default instead of inserting before it: Synapse
-  /// rejects `?before=.m.rule.*` (default rules can't be used as a
-  /// before/after anchor in this version). Disabling the default
-  /// removes its dont_notify entirely; non-join member events
-  /// (leaves, profile changes) then match no override rule and
-  /// silently fall through, which matches the allowlist policy.
-  Future<void> _ensureGroupJoinPushRule() async {
+  /// Idempotently undo PR #222/#223:
+  /// - delete the `grid.member.join` override rule (no longer needed)
+  /// - re-enable `.m.rule.member_event` (we no longer want every member
+  ///   event to fire; the spec default of suppressing them is correct)
+  Future<void> _resetCustomPushRules() async {
     try {
       await client.request(
-        RequestType.PUT,
+        RequestType.DELETE,
         '/client/v3/pushrules/global/override/grid.member.join',
-        data: {
-          'actions': ['notify'],
-          'conditions': [
-            {'kind': 'event_match', 'key': 'type', 'pattern': 'm.room.member'},
-            {
-              'kind': 'event_match',
-              'key': 'content.membership',
-              'pattern': 'join',
-            },
-          ],
-        },
       );
-      debugPrint('[Push] Override rule grid.member.join set');
-    } catch (e) {
-      debugPrint('[Push] Failed to set grid.member.join rule: $e');
+      debugPrint('[Push] Removed override rule grid.member.join');
+    } catch (_) {
+      // 404 if it never existed for this user — fine.
     }
-
     try {
       await client.request(
         RequestType.PUT,
         '/client/v3/pushrules/global/override/.m.rule.member_event/enabled',
-        data: {'enabled': false},
+        data: {'enabled': true},
       );
-      debugPrint('[Push] Disabled default .m.rule.member_event');
+      debugPrint('[Push] Re-enabled default .m.rule.member_event');
     } catch (e) {
-      debugPrint('[Push] Failed to disable .m.rule.member_event: $e');
+      debugPrint('[Push] Failed to re-enable .m.rule.member_event: $e');
     }
   }
 
@@ -181,23 +161,20 @@ class PushNotificationService {
   Future<void> _setPusher(PusherConfig config) async {
     final deviceName = await _deviceDisplayName();
 
-    // `default_payload` is a sygnal feature: it is merged into every APNs
-    // payload Sygnal generates. With `format: event_id_only` Sygnal by default
-    // emits a payload with **no `aps` dict**, which makes iOS drop the push
-    // silently (the NSE never even runs). We force `mutable-content: 1` so the
-    // NSE gets a chance to classify and either fill in or suppress the alert.
+    // `default_payload` is a sygnal feature merged into every APNs payload.
+    // With `format: event_id_only` Sygnal by default emits a payload with no
+    // `aps` dict, so iOS drops the push silently (NSE never runs). We force
+    // `mutable-content: 1` so the NSE gets invoked.
     //
-    // The placeholder body is overwritten by the NSE on every push the user
-    // should see, and suppressed to empty for every other push. It is only
-    // visible if the NSE fails to run (hard OS-level failure) and iOS falls
-    // back to rendering the raw APNs payload — which we prefer to silence
-    // than to surface as a leak.
+    // We deliberately do NOT include an `alert` here. Without an alert, iOS
+    // only renders a banner if the NSE actively *adds* one. That's exactly
+    // what we want under the allowlist policy: events the NSE classifier
+    // approves get a banner; everything else is silent. (When we did set
+    // a placeholder alert, the NSE's "suppress" path leaked an empty
+    // banner because iOS still rendered the original alert.)
     final defaultPayload = <String, dynamic>{
       'aps': <String, dynamic>{
         'mutable-content': 1,
-        'alert': <String, dynamic>{
-          'body': ' ',
-        },
       },
     };
 

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -1408,6 +1408,14 @@ class SyncManager with ChangeNotifier {
           }
           
           groupsBloc.add(RefreshGroups());
+
+          // Post a synthetic "X joined GROUP" system message so the
+          // existing members get a push notification. We can't push on
+          // raw m.room.member joins (Matrix's default `.m.rule.member_event`
+          // suppresses them and Synapse won't let us reorder defaults),
+          // so we ride on top of the regular `.m.rule.message` rule with
+          // a custom msgtype the NSE allowlist recognizes.
+          await _postSyntheticJoinMessage(roomId);
         }
       } else {
         throw Exception('Failed to join room');
@@ -1415,6 +1423,42 @@ class SyncManager with ChangeNotifier {
     } catch (e) {
       print('Error during room join and sync: $e');
       throw e; // Re-throw for error handling in calling code
+    }
+  }
+
+  /// Send a `m.room.message` with a custom Grid msgtype announcing
+  /// that the local user just joined this room. Skipped for direct
+  /// rooms — joins there are friendship accepts and have their own
+  /// notification path.
+  Future<void> _postSyntheticJoinMessage(String roomId) async {
+    final room = client.getRoomById(roomId);
+    if (room == null) return;
+
+    final name = room.name;
+    if (!name.startsWith('Grid:Group:')) {
+      // Direct room or untyped room — don't post a join announcement.
+      return;
+    }
+
+    // "Grid:Group:<ts>:<groupName>:<creator MXID>"
+    final rest = name.substring('Grid:Group:'.length);
+    final parts = rest.split(':');
+    final groupName = (parts.length >= 2) ? parts[1] : 'a group';
+
+    final me = client.userID ?? 'Someone';
+    final myName = me.startsWith('@')
+        ? me.substring(1, me.contains(':') ? me.indexOf(':') : me.length)
+        : me;
+    final body = '$myName joined $groupName';
+
+    try {
+      await room.sendEvent({
+        'msgtype': 'grid.member.join',
+        'body': body,
+      });
+      print('[Push] Posted synthetic join: $body');
+    } catch (e) {
+      print('[Push] Failed to post synthetic join message: $e');
     }
   }
 


### PR DESCRIPTION
## Summary
Three coupled fixes to make the push policy actually work end-to-end:

**1. Drop placeholder alert from `default_payload`.** Sygnal was sending `aps: { mutable-content: 1, alert: { body: " " } }`, so even when the NSE classifier suppressed an event the original alert leaked through and iOS rendered an empty banner. Without an alert in the original payload, iOS only renders if the NSE *actively adds one* — which is exactly what the allowlist policy wants.

**2. Revert PR #222 / #223 push rule overrides.** Trying to make `m.room.member` joins push by overriding default rules turned into a fight with Synapse (`?before=.m.rule.*` rejected, disabling default left accounts in a weird state). NSE-side allowlist is the single source of truth for what renders.

**3. Synthetic `grid.member.join` messages for group joins.** When the local user joins a `Grid:Group:` room, the app posts an `m.room.message` with `msgtype="grid.member.join"` and body `"<user> joined <group>"`. Rides on top of the default `.m.rule.message` rule (no rule changes needed). NSE classifier allowlists the custom msgtype and renders the body verbatim. Direct rooms are skipped — those are friendship accepts and have their own path.

After this, the policy works without server-side push rule manipulation:
- Invites (group + direct) → NSE invite-state fallback renders parsed Grid room name
- Group joins → joining user's app posts synthetic message → standard message push → NSE allowlists the msgtype → banner
- Friendship accepts → NSE classifier handles direct-room joins
- Everything else → NSE suppresses, no alert was in default_payload, iOS shows nothing

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed iOS push notifications: messages no longer leak as blank banners; group joins now actually push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
