### PR TITLE
Fix release Android Firebase + hide subscription UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,10 @@ jobs:
         run: |
           cp "$HOME/.fastlane-secrets/GoogleService-Info.plist" ios/Runner/GoogleService-Info.plist
 
+      - name: Restore Firebase Android config
+        run: |
+          cp "$HOME/.fastlane-secrets/google-services.json" android/app/google-services.json
+
       - name: Build iOS
         run: |
           export PATH="/opt/homebrew/bin:$PATH"

--- a/changes/pr-228.md
+++ b/changes/pr-228.md
@@ -1,0 +1,1 @@
+[fix] Hide subscriptions and satellite map while sat-tile provider is offline; fix Android release build.

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -2576,28 +2576,31 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
               colorScheme: colorScheme,
               isDarkMode: isDarkMode,
             ),
-            SizedBox(height: 8),
-            // Satellite Map Option
-            _buildMapOption(
-              title: 'Satellite Map',
-              imagePath: 'assets/extras/satellite.png',
-              isSelected: _currentMapStyle == 'satellite',
-              showStar: true,
-              onTap: _isLoadingMapStyle ? null : () async {
-                final hasSubscription = await _subscriptionService.hasActiveSubscription();
-                if (!hasSubscription) {
-                  // Navigate to subscription page
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (context) => SubscriptionScreen()),
-                  );
-                } else {
-                  _selectMapStyle('satellite');
-                }
-              },
-              colorScheme: colorScheme,
-              isDarkMode: isDarkMode,
-            ),
+            // Satellite Map hidden while the sat-tile provider is offline.
+            // Re-enable by removing the `if (false)` guard once available.
+            if (false) ...[
+              SizedBox(height: 8),
+              _buildMapOption(
+                title: 'Satellite Map',
+                imagePath: 'assets/extras/satellite.png',
+                isSelected: _currentMapStyle == 'satellite',
+                showStar: true,
+                onTap: _isLoadingMapStyle ? null : () async {
+                  final hasSubscription = await _subscriptionService.hasActiveSubscription();
+                  if (!hasSubscription) {
+                    // Navigate to subscription page
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => SubscriptionScreen()),
+                    );
+                  } else {
+                    _selectMapStyle('satellite');
+                  }
+                },
+                colorScheme: colorScheme,
+                isDarkMode: isDarkMode,
+              ),
+            ],
           ],
         ],
       ),

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -2187,7 +2187,9 @@ class _SettingsPageState extends State<SettingsPage> {
             ],
 
             // Subscriptions Section (only for default homeserver)
-            if (!isCustomHomeserver()) ...[
+            // Hidden while sat-map provider is offline; re-enable by removing
+            // the `false &&` once subscriptions can deliver value again.
+            if (false && !isCustomHomeserver()) ...[
               _buildSectionCard(
                 theme: theme,
                 colorScheme: colorScheme,


### PR DESCRIPTION
## Summary

Two bundled fixes to unblock the 1.1.2 release:

1. **`.github/workflows/release.yml`** — Add the Android `google-services.json` restore step. PR #210 added this to `ci.yml` but missed `release.yml`, so every release run since fails at `:app:processReleaseGoogleServices`.

2. **Hide subscription UI** — sat-tile provider relationship ended; we can't deliver the premium value right now. Two entry points wrapped in `if (false)`:
   - Settings → "Manage Subscriptions" menu
   - Map style picker → "Satellite Map" option (would push to a dead-end subscribe page)

Subscription service code (`subscription_service.dart`, `apple_subscription_service.dart`, all gating logic in `map_tab`/`location_history_modal`/etc.) is left **intact** — re-enable later by removing the `if (false)` guards.

## Test plan

- [ ] CI Android build passes (the actual fix this PR is verifying)
- [ ] Settings page no longer shows "Subscriptions" section
- [ ] Map style picker shows only "Standard Map", no "Satellite Map" entry
- [ ] No code path can land on `SubscriptionScreen` (verified via grep — only 4 push sites, all now behind `if (false)`)

## Changelog

- [ ] `skip`
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`

**Release note:**
Hide subscriptions and satellite map while sat-tile provider is offline; fix Android release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)