### PR TITLE
Fix Apple 5.1.1: don't auto-open Settings after location denial

### DIFF
--- a/changes/pr-229.md
+++ b/changes/pr-229.md
@@ -1,0 +1,1 @@
+[fix] Fixed iOS onboarding redirecting users to Settings after declining the location permission prompt.

--- a/lib/widgets/onboarding_modal.dart
+++ b/lib/widgets/onboarding_modal.dart
@@ -194,11 +194,20 @@ class _OnboardingModalState extends State<OnboardingModal>
           locationGranted = true;
           break;
         case LocationPermission.denied:
+          // First denial: stay on the onboarding screen so the user can
+          // tap "Allow Location" again to re-prompt. App Review
+          // (Guideline 5.1.1) explicitly disallows auto-redirecting to
+          // Settings after a denial.
+          print('[Onboarding] Permission denied; user can retry');
+          break;
         case LocationPermission.deniedForever:
-          // Denied - need to go to settings
-          print('[Onboarding] Permission denied, opening settings');
-          await _showSettingsDialog('Location');
-          return;
+          // OS won't show the system prompt again. Show an in-app message
+          // explaining how to enable manually — but the Settings link is a
+          // user-initiated action (SnackBarAction), not an automatic
+          // redirect. Required by App Review guideline 5.1.1.
+          print('[Onboarding] Permission deniedForever; offering manual settings link');
+          _showLocationDeniedNotice();
+          break;
       }
 
       print('[Onboarding] Final permission granted: $locationGranted');
@@ -208,8 +217,28 @@ class _OnboardingModalState extends State<OnboardingModal>
       });
     } catch (e) {
       print('[Onboarding] ERROR requesting location permission: $e');
-      await _showSettingsDialog('Location');
     }
+  }
+
+  void _showLocationDeniedNotice() {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: const Text(
+          'Location access is needed to share your location with friends. '
+          'You can enable it in Settings.',
+        ),
+        duration: const Duration(seconds: 6),
+        behavior: SnackBarBehavior.floating,
+        action: SnackBarAction(
+          label: 'Open Settings',
+          onPressed: () async {
+            await openAppSettings();
+            await _checkPermissionStatus();
+          },
+        ),
+      ),
+    );
   }
 
   Future<void> _requestActivityPermission() async {
@@ -251,28 +280,6 @@ class _OnboardingModalState extends State<OnboardingModal>
         _activityRecognitionGranted = true;
       });
     }
-  }
-
-  Future<void> _showSettingsDialog(String permissionName) async {
-    // Show a clean snackbar instead of ugly dialog
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Opening Settings to enable $permissionName'),
-          duration: const Duration(seconds: 2),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
-    }
-
-    // Small delay so user sees the message
-    await Future.delayed(const Duration(milliseconds: 300));
-
-    // Go straight to settings
-    await openAppSettings();
-
-    // Check permissions when user comes back
-    await _checkPermissionStatus();
   }
 
   Future<void> _checkPermissionStatus() async {


### PR DESCRIPTION
## Summary

Apple App Review rejection — Guideline 5.1.1(iv):

> The user is redirected to the Settings app to grant access after tapping "Don't Allow".

Onboarding's `_requestLocationPermission` was calling `_showSettingsDialog` (which calls `openAppSettings()`) the instant iOS returned `denied` or `deniedForever`. That's exactly what Apple flagged.

## Behavior change

| State | Before | After |
|---|---|---|
| `denied` (first tap of "Don't Allow") | Auto-redirect to iOS Settings | Stay on onboarding; user can tap "Allow Location" again to re-prompt |
| `deniedForever` (system won't prompt again) | Auto-redirect to iOS Settings | Show a snackbar explaining why location is needed, with an **"Open Settings"** action button. Tapping the button is the only way Settings opens — fully user-initiated. |

This matches Apple's resolution guidance verbatim:
> If the user is trying to use a feature in the app that won't function without access to the location, you may include a notification to inform the user and provide a link to the Settings app.

## Test plan

- [ ] Fresh install on real iOS device (or wipe location permission via Settings → Grid → Location → Never)
- [ ] In onboarding, tap "Allow Location" → iOS prompt appears → tap "Don't Allow"
  - **Expected:** stay on onboarding screen, no Settings redirect
  - "Allow Location" button still tappable; tapping again re-prompts
- [ ] Tap "Don't Allow" twice (or set to "Never" in Settings) → re-enter onboarding → tap "Allow Location"
  - **Expected:** snackbar appears with "Open Settings" action; no auto-redirect
  - Tapping "Open Settings" opens the app's Settings page; coming back updates onboarding state
- [ ] Grant permission → onboarding proceeds normally

## Changelog

- [ ] `skip`
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`

**Release note:**
Fixed iOS onboarding redirecting users to Settings after declining the location permission prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)