### PR TITLE
fix: remove USE_EXACT_ALARM and simplify release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,37 +130,12 @@ jobs:
           export PATH="/opt/homebrew/lib/ruby/gems/3.3.0/bin:/opt/homebrew/opt/ruby@3.3/bin:/opt/homebrew/bin:$PATH"
           fastlane ios beta
 
-      - name: Submit iOS to App Store Review
-        run: |
-          export LC_ALL=en_US.UTF-8
-          export LANG=en_US.UTF-8
-          export PATH="/opt/homebrew/lib/ruby/gems/3.3.0/bin:/opt/homebrew/opt/ruby@3.3/bin:/opt/homebrew/bin:$PATH"
-
-          # Write release notes for deliver
-          mkdir -p fastlane/metadata/en-US
-          bash scripts/build-release-notes.sh > fastlane/metadata/en-US/release_notes.txt
-
-          fastlane ios release
-
       - name: Upload Android to Play Store Internal
         run: |
           export LC_ALL=en_US.UTF-8
           export LANG=en_US.UTF-8
           export PATH="/opt/homebrew/lib/ruby/gems/3.3.0/bin:/opt/homebrew/opt/ruby@3.3/bin:/opt/homebrew/bin:$PATH"
           fastlane android beta
-
-      - name: Promote Android to Production
-        run: |
-          export LC_ALL=en_US.UTF-8
-          export LANG=en_US.UTF-8
-          export PATH="/opt/homebrew/lib/ruby/gems/3.3.0/bin:/opt/homebrew/opt/ruby@3.3/bin:/opt/homebrew/bin:$PATH"
-
-          # Write release notes for Play Store
-          BUILD_NUMBER="${{ steps.version.outputs.build_number }}"
-          mkdir -p fastlane/metadata/android/en-US/changelogs
-          bash scripts/build-release-notes.sh > "fastlane/metadata/android/en-US/changelogs/${BUILD_NUMBER}.txt"
-
-          fastlane android release
 
       - name: Create GitHub Release
         run: |
@@ -173,8 +148,8 @@ jobs:
           ${STORE_NOTES}
 
           ---
-          - 📱 iOS: Submitted to App Store Review
-          - 🤖 Android: Promoted to Production" \
+          - 📱 iOS: Uploaded to TestFlight (manual App Store release)
+          - 🤖 Android: Uploaded as draft to Play Store internal (manual promotion)" \
             build/ios/ipa/Grid.ipa \
             build/app/outputs/bundle/release/app-release.aab \
             build/app/outputs/flutter-apk/app-release.apk

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
 
+    <!-- Removed by manifest merger: libre_location declares USE_EXACT_ALARM,
+         which Google Play restricts to calendar/alarm-clock apps. -->
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" tools:node="remove" />
+
 
     <application
         android:label="Grid"

--- a/changes/pr-232.md
+++ b/changes/pr-232.md
@@ -1,0 +1,1 @@
+[fix] Removed an Android permission that triggered a Google Play policy warning.


### PR DESCRIPTION
## What changed

- **`USE_EXACT_ALARM` permission removed.** Google Play flagged it as restricted to calendar/alarm-clock apps. The permission was pulled in transitively by the `libre_location` plugin's manifest; stripped via manifest merger (`tools:node="remove"`) at the app level. `SCHEDULE_EXACT_ALARM` (the user-prompted variant) is still allowed and remains in place, so the plugin's heartbeat alarm path still works.
- **Release pipeline simplified.** Dropped the auto App Store Review submission and auto Play Store production promotion. Both stores now stop at TestFlight / Play Store internal draft; promotion is manual. This removes two failure modes that were wedging entire release runs (e.g. a failed iOS review submit was preventing the Android upload from happening at all).

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Removed an Android permission that triggered a Google Play policy warning.