### PR TITLE
fix: strip SCHEDULE_EXACT_ALARM to unblock Play Store uploads

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,9 +8,13 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Removed by manifest merger: libre_location declares USE_EXACT_ALARM,
-         which Google Play restricts to calendar/alarm-clock apps. -->
+    <!-- Removed by manifest merger: libre_location declares both exact-alarm
+         permissions for its heartbeat. USE_EXACT_ALARM is restricted to
+         calendar/alarm-clock apps; SCHEDULE_EXACT_ALARM requires a Play
+         Console declaration that gets rejected for non-calendar/alarm apps.
+         Heartbeat doesn't need exact timing here. -->
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" tools:node="remove" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" tools:node="remove" />
 
 
     <application


### PR DESCRIPTION
## What changed

Adds a manifest-merger removal for `SCHEDULE_EXACT_ALARM` in addition to the `USE_EXACT_ALARM` removal we landed in #232.

**Why the second one is needed:** Google Play's API now refuses uploads of apps that declare `SCHEDULE_EXACT_ALARM` without a Play Console exact-alarm-usage declaration, and the declaration is only accepted for calendar / alarm-clock apps. The plugin's heartbeat doesn't actually need exact timing here — drift of a few minutes during Doze is fine for background location. Stripping the permission unblocks the upload.

The `libre_location` plugin will be updated upstream to drop both permissions and switch to inexact alarms / WorkManager (separate work in `Rezivure/libre-location`). This PR is the interim app-side fix so we can ship.

Verified locally: `flutter build appbundle --release` succeeds and the merged release manifest has zero `EXACT_ALARM` permissions.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Removed Android exact-alarm permissions that were blocking Play Store releases.