### PR TITLE
chore: bump libre_location to 0.3.0 and drop alarm-permission overrides

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,14 +8,6 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Removed by manifest merger: libre_location declares both exact-alarm
-         permissions for its heartbeat. USE_EXACT_ALARM is restricted to
-         calendar/alarm-clock apps; SCHEDULE_EXACT_ALARM requires a Play
-         Console declaration that gets rejected for non-calendar/alarm apps.
-         Heartbeat doesn't need exact timing here. -->
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" tools:node="remove" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" tools:node="remove" />
-
 
     <application
         android:label="Grid"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1075,10 +1075,10 @@ packages:
     dependency: "direct main"
     description:
       name: libre_location
-      sha256: dcbeb990ca6dec6b2ca8d57846050287760f05488f4331cb1767657e91e1517b
+      sha256: "5e052dee026d034c3fae56e96231c9ae4b820989a053a75dd7355369028071d2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.3.0"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   flutter_bloc: ^8.1.6
   collection: ^1.18.0
   equatable: ^2.0.7
-  libre_location: ^0.2.1
+  libre_location: ^0.3.0
   hive: ^2.2.3
   qr_code_scanner_plus: ^2.0.6
   package_info_plus: ^8.1.2


### PR DESCRIPTION
## What changed

- `pubspec.yaml`: `libre_location: ^0.2.1` → `^0.3.0` (lockfile updated to 0.3.0).
- `android/app/src/main/AndroidManifest.xml`: removed the `USE_EXACT_ALARM` and `SCHEDULE_EXACT_ALARM` `tools:node="remove"` entries we added in #232 and #233.

## Why

`libre_location` 0.3.0 (just published) removed both exact-alarm permissions from its own manifest and replaced the `AlarmManager`-based heartbeat with an in-process `Handler.postDelayed` loop. With the source of those permissions gone, the manifest-merger overrides become no-ops — cleaner to drop them.

## Behaviour notes (carried from upstream 0.3.0)

- Heartbeats now fire while the foreground service process is alive; may pause during deep Doze (rare in practice given the foreground notification + battery exemption).
- The watchdog alarm (15-min OEM-kill recovery) is gone. OEM-kill resilience now relies entirely on the foreground service notification + `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`.

## Verification

- `flutter pub get` resolves `libre_location 0.3.0`
- `flutter build appbundle --release` succeeds
- Merged release manifest contains zero `EXACT_ALARM` permissions

## Changelog

- [ ] \`skip\` — No user-facing changes
- [ ] \`feature\` — New functionality
- [ ] \`fix\` — Bug fix
- [x] \`improvement\` — Enhancement

**Release note:**
Updated background location plugin to drop Android exact-alarm permissions.