### PR TITLE
chore: drop unused libre_location heartbeat subscription

### DIFF
--- a/lib/services/location/libre_location_service.dart
+++ b/lib/services/location/libre_location_service.dart
@@ -17,7 +17,6 @@ class LibreLocationService implements LocationService {
 
   StreamSubscription<libre.Position>? _positionSubscription;
   StreamSubscription<libre.Position>? _motionSubscription;
-  StreamSubscription<libre.HeartbeatEvent>? _heartbeatSubscription;
   StreamSubscription<libre.ActivityEvent>? _activitySubscription;
   StreamSubscription<libre.ProviderEvent>? _providerSubscription;
   StreamSubscription<bool>? _powerSaveSubscription;
@@ -90,17 +89,6 @@ class LibreLocationService implements LocationService {
         });
       });
 
-      // Listen for heartbeat events (periodic pings when stationary)
-      _heartbeatSubscription = libre.LibreLocation.onHeartbeat.listen((event) {
-        DebugLogService.instance.log('heartbeat', {
-          'latitude': event.position.latitude,
-          'longitude': event.position.longitude,
-          'accuracy': event.position.accuracy,
-          'speed': event.position.speed,
-          'isMoving': event.position.isMoving,
-        });
-      });
-
       // Listen for activity changes (still/walking/driving/cycling)
       _activitySubscription = libre.LibreLocation.onActivityChange.listen((event) {
         DebugLogService.instance.log('activity_change', {
@@ -162,13 +150,11 @@ class LibreLocationService implements LocationService {
       
       await _positionSubscription?.cancel();
       await _motionSubscription?.cancel();
-      await _heartbeatSubscription?.cancel();
       await _activitySubscription?.cancel();
       await _providerSubscription?.cancel();
       await _powerSaveSubscription?.cancel();
       _positionSubscription = null;
       _motionSubscription = null;
-      _heartbeatSubscription = null;
       _activitySubscription = null;
       _providerSubscription = null;
       _powerSaveSubscription = null;


### PR DESCRIPTION
## What changed

Removed the \`onHeartbeat\` stream subscription from \`LibreLocationService\` (and the corresponding field declaration + cancel/null lines on stop).

## Why

The handler did nothing meaningful — it only wrote one entry to \`DebugLogService\`. No backend send, no Matrix push, no contact-sharing update, no UI bind. With no consumer of the data, paying for the subscription buys nothing.

Bonus: this also makes the \`Handler.postDelayed\` heartbeat loop on the Android side (libre_location 0.3.0) genuinely irrelevant for Grid — even if it pauses during deep Doze, we weren't going to do anything with the tick anyway.

iOS has no heartbeat path and works fine, which is the proof this is dead weight.

## Verification

- \`flutter analyze\` — no new issues from this change (only pre-existing \`info\`-level diagnostics)
- Behaviour unchanged for users

## Changelog

- [x] \`skip\` — No user-facing changes
- [ ] \`feature\` — New functionality
- [ ] \`fix\` — Bug fix
- [ ] \`improvement\` — Enhancement

**Release note:**