### PR TITLE
ci: bump build-number offset to 709 (next build = 734)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           export PATH="/opt/homebrew/bin:$PATH"
           VERSION_NAME=$(grep '^version:' pubspec.yaml | sed 's/version: *//;s/+.*//')
-          BUILD_NUMBER=$(( ${{ github.run_number }} + 500 ))
+          BUILD_NUMBER=$(( ${{ github.run_number }} + 709 ))
           sed -i '' "s/^version: .*/version: ${VERSION_NAME}+${BUILD_NUMBER}/" pubspec.yaml
           echo "📦 Release version: ${VERSION_NAME}+${BUILD_NUMBER}"
           echo "version=${VERSION_NAME}+${BUILD_NUMBER}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Bump the CI's `BUILD_NUMBER` offset from `500` to `709` so the next release run produces `1.1.2+734` for both stores.

## Why

Play Store has versionCode `733` on the Internal track. Google's monotonic-versionCode rule means any future release on that track must be `>=734`. Old offset (`run_number + 500`) on the next run would yield `525` — rejected. New offset: `709 + 25 (next run_number) = 734`. ✅

## Changelog

- [x] `skip`
- [ ] `feature`
- [ ] `fix`
- [ ] `improvement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)