### PR TITLE
fix: add 15-second timeout to login and session-restore network calls

### DIFF
--- a/changes/pr-239.md
+++ b/changes/pr-239.md
@@ -1,0 +1,1 @@
+[fix] Fixed app hang on login and re-open when network is slow or unavailable — calls now time out after 15 seconds and show a dismissible error so the user can retry.

--- a/lib/screens/onboarding/login_screen.dart
+++ b/lib/screens/onboarding/login_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:matrix/matrix.dart';
@@ -93,11 +95,17 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
       final Uri homeserverUri = homeserver.startsWith('http://') || homeserver.startsWith('https://')
           ? Uri.parse(homeserver)
           : Uri.https(homeserver, '');
-      await client.checkHomeserver(homeserverUri);
+      await client.checkHomeserver(homeserverUri).timeout(
+        const Duration(seconds: 15),
+        onTimeout: () => throw TimeoutException('Could not reach homeserver. Check your connection and try again.'),
+      );
       await client.login(
         LoginType.mLoginPassword,
         password: _passwordController.text,
         identifier: AuthenticationUserIdentifier(user: _usernameController.text),
+      ).timeout(
+        const Duration(seconds: 15),
+        onTimeout: () => throw TimeoutException('Login timed out. Check your connection and try again.'),
       );
 
       setState(() {

--- a/lib/screens/onboarding/splash_screen.dart
+++ b/lib/screens/onboarding/splash_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:matrix/matrix.dart';
@@ -113,10 +115,12 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
         if (customHomeserver != null && customHomeserver.isNotEmpty) {
           // For custom servers, we need to set the homeserver before checking if logged in
           try {
-            await client.checkHomeserver(Uri.https(customHomeserver, ''));
+            await client.checkHomeserver(Uri.https(customHomeserver, '')).timeout(
+              const Duration(seconds: 15),
+            );
           } catch (e) {
-            // If we can't reach the custom server (offline), still set it as the homeserver
-            // so isCustomHomeserver() will work correctly
+            // If we can't reach the custom server (offline or timed out), still set it as the
+            // homeserver so isCustomHomeserver() will work correctly
             print('Could not reach custom homeserver (may be offline): $e');
             // Manually set the homeserver URL even if offline
             client.homeserver = Uri.https(customHomeserver, '');
@@ -124,9 +128,11 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
         } else {
           // For default server, ensure the homeserver is set even if offline
           try {
-            await client.checkHomeserver(Uri.parse(dotenv.env['MATRIX_SERVER_URL']!));
+            await client.checkHomeserver(Uri.parse(dotenv.env['MATRIX_SERVER_URL']!)).timeout(
+              const Duration(seconds: 15),
+            );
           } catch (e) {
-            // If offline, manually set the default homeserver
+            // If offline or timed out, manually set the default homeserver
             print('Could not reach default homeserver (may be offline): $e');
             final defaultUrl = dotenv.env['MATRIX_SERVER_URL'] ?? 'https://matrix.mygrid.app';
             client.homeserver = Uri.parse(defaultUrl);


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#28

## What changed

- `lib/screens/onboarding/login_screen.dart`: Added `import 'dart:async'` and wrapped `client.checkHomeserver()` and `client.login()` each in a `Future.timeout(Duration(seconds: 15))` with a `TimeoutException` on timeout. The existing error-card UI surfaces the message so the user can retry.
- `lib/screens/onboarding/splash_screen.dart`: Added `import 'dart:async'` and wrapped both `client.checkHomeserver()` calls (custom homeserver path and default homeserver path) in a `Future.timeout(Duration(seconds: 15))`. Both already fall through to a safe offline fallback on any exception, so a timeout now terminates the wait rather than hanging the splash indefinitely.

## Why

The app sometimes hangs forever on login or re-open due to unbounded network calls to `checkHomeserver()` and `client.login()`. On a bad or slow connection these futures never complete, leaving the user stuck with a spinner and no way to recover without force-quitting.

## Risk

- The 15-second threshold is intentional and generous; it could feel slow on extremely poor connections but is far preferable to an infinite hang.
- Both sites already had `catch (e)` handlers — the timeout exception is caught by those same handlers, so no new code paths are introduced beyond the throw.
- Splash-screen timeouts fall into the existing offline-fallback path, so restoring a session without network connectivity continues to work as before.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed app hang on login and re-open when network is slow or unavailable — calls now time out after 15 seconds and show a dismissible error so the user can retry.

_Agent-generated by the daily-issue-pipeline routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnbZfDisaR4Kr72YMJaRC1)_