### PR TITLE
fix: add 30s timeout guards to login and map provider calls (#28)

### DIFF
--- a/changes/pr-240.md
+++ b/changes/pr-240.md
@@ -1,0 +1,1 @@
+[fix] Add 30-second timeout to login and map-tile-provider calls to prevent the app from hanging on bad network conditions.

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -1054,7 +1054,10 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
       _tileProvider = null;
 
       _mapTheme = ProtomapsThemes.light();
-      _tileProvider = await PmTilesVectorTileProvider.fromSource(mapUrl);
+      _tileProvider = await PmTilesVectorTileProvider.fromSource(mapUrl)
+          .timeout(const Duration(seconds: 30), onTimeout: () {
+        throw TimeoutException('Map provider load timed out. Please check your connection.');
+      });
 
       context.read<MapBloc>().add(MapInitialize());
       setState(() {});

--- a/lib/screens/onboarding/login_screen.dart
+++ b/lib/screens/onboarding/login_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:matrix/matrix.dart';
@@ -93,12 +95,17 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
       final Uri homeserverUri = homeserver.startsWith('http://') || homeserver.startsWith('https://')
           ? Uri.parse(homeserver)
           : Uri.https(homeserver, '');
-      await client.checkHomeserver(homeserverUri);
+      await client.checkHomeserver(homeserverUri)
+          .timeout(const Duration(seconds: 30), onTimeout: () {
+        throw TimeoutException('Homeserver check timed out. Please check your connection and try again.');
+      });
       await client.login(
         LoginType.mLoginPassword,
         password: _passwordController.text,
         identifier: AuthenticationUserIdentifier(user: _usernameController.text),
-      );
+      ).timeout(const Duration(seconds: 30), onTimeout: () {
+        throw TimeoutException('Login timed out. Please check your connection and try again.');
+      });
 
       setState(() {
         _isLoading = false;


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#28

## What changed
- `lib/screens/onboarding/login_screen.dart`: Added `.timeout(Duration(seconds: 30))` with `TimeoutException` to both `client.checkHomeserver()` and `client.login()` calls inside `_login()`; added `dart:async` import.
- `lib/screens/map/map_tab.dart`: Added `.timeout(Duration(seconds: 30))` with `TimeoutException` to `PmTilesVectorTileProvider.fromSource(mapUrl)` inside `_loadMapProvider()`; `dart:async` was already imported.

## Why
The app would hang indefinitely when `checkHomeserver()`, `login()`, or `PmTilesVectorTileProvider.fromSource()` stalled on a slow or broken network. A 30-second timeout causes those futures to throw a `TimeoutException`, which is caught by the existing error handlers and surfaces a recoverable error message to the user instead of an infinite spinner.

## Risk
Low. The change is purely additive — existing `catch (e)` blocks in both methods already handle thrown exceptions gracefully (`_errorMessage` shown on login, `_showMapErrorDialog()` shown on map). The 30-second window is generous enough to avoid false positives on slow-but-functional connections.

- [x] `fix`

**Release note:**
Add 30-second timeout to login and map-tile-provider calls to prevent the app from hanging on bad network conditions.

_Agent-generated by the daily-issue-pipeline routine._