### PR TITLE
chore: point map URL at v2 protomaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           MATRIX_SERVER_URL=https://matrix.mygrid.app
           GAUTH_URL=https://gauth.mygrid.app
           HOMESERVER=matrix.mygrid.app
-          MAPS_URL=https://map.mygrid.app/v1/protomaps.pmtiles
+          MAPS_URL=https://map.mygrid.app/v2/v2_protomaps_20260512.pmtiles
           VERSION_CHECK_URL=https://version.mygrid.app
           EOF
 

--- a/changes/pr-242.md
+++ b/changes/pr-242.md
@@ -1,0 +1,1 @@
+[improvement] Map data refreshed.

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -1048,7 +1048,7 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
       }
 
       final prefs = await SharedPreferences.getInstance();
-      final mapUrl = prefs.getString('maps_url') ?? 'https://map.mygrid.app/v1/protomaps.pmtiles';
+      final mapUrl = prefs.getString('maps_url') ?? 'https://map.mygrid.app/v2/v2_protomaps_20260512.pmtiles';
 
       // Clear existing tile provider to force complete reinitialization
       _tileProvider = null;

--- a/lib/widgets/location_history_modal.dart
+++ b/lib/widgets/location_history_modal.dart
@@ -92,7 +92,7 @@ class _LocationHistoryModalState extends State<LocationHistoryModal> {
       
       // Initialize base map provider (still needed for fallback)
       if (_currentMapStyle == 'base') {
-        final mapUrl = prefs.getString('maps_url') ?? 'https://map.mygrid.app/v1/protomaps.pmtiles';
+        final mapUrl = prefs.getString('maps_url') ?? 'https://map.mygrid.app/v2/v2_protomaps_20260512.pmtiles';
         _mapTheme = ProtomapsThemes.light();
         _tileProvider = await PmTilesVectorTileProvider.fromSource(mapUrl);
       }


### PR DESCRIPTION
## Summary

Cutover to the new v2 protomaps file uploaded to R2 at `grid-maps-protomaps/v2/v2_protomaps_20260512.pmtiles`.

**Worker (`Rezivure/Grid-Protomaps`)** has already been redeployed to handle this:
- `/v1/foo.pmtiles` → bucket root (legacy behavior, **preserved** for already-shipped builds)
- `/v2/foo.pmtiles` → `v2/foo.pmtiles` in R2 (new)

Smoke-tested both paths return HTTP 200.

## Files changed

- `.github/workflows/release.yml` — new `MAPS_URL` baked into CI `.env`
- `lib/screens/map/map_tab.dart:1051` — default fallback URL
- `lib/widgets/location_history_modal.dart:95` — default fallback URL

Local `.env` updated separately (gitignored).

## Changelog

- [ ] `skip`
- [ ] `feature`
- [ ] `fix`
- [x] `improvement`

**Release note:**
Map data refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)