### PR TITLE
fix: strip duplicate @ prefix when building Matrix IDs for invites (#85)

### DIFF
--- a/lib/services/room_service.dart
+++ b/lib/services/room_service.dart
@@ -603,13 +603,16 @@ class RoomService {
       );
 
       for (final user in userIds) {
-        var fullMatrixId = user;
+        // Strip any stray leading '@' before constructing the full Matrix ID
+        // so that stored usernames and copy-pasted IDs are handled consistently.
+        final cleanUser = user.startsWith('@') ? user.substring(1) : user;
+        final String fullMatrixId;
         final isCustomServ = isCustomHomeserver();
         if (isCustomServ) {
-          fullMatrixId = '@$fullMatrixId';
+          fullMatrixId = '@$cleanUser';
         } else {
           final homeserver = getMyHomeserver().replaceFirst('https://', '');
-          fullMatrixId = '@$user:$homeserver';
+          fullMatrixId = '@$cleanUser:$homeserver';
         }
         await client.inviteUser(roomId, fullMatrixId);
       }

--- a/lib/widgets/add_friend_modal.dart
+++ b/lib/widgets/add_friend_modal.dart
@@ -152,7 +152,7 @@ class _AddFriendModalState extends State<AddFriendModal> with TickerProviderStat
     }
     
     var normalizedUserId = rawInput.toLowerCase();
-    
+
     // Check if this is from QR scan (already has @ prefix)
     if (_friendQrCodeScan != null && normalizedUserId.startsWith('@')) {
       // QR code contains full matrix ID
@@ -164,7 +164,12 @@ class _AddFriendModalState extends State<AddFriendModal> with TickerProviderStat
       }
       // For custom homeserver, use as-is
     } else {
-      // Manual input from text field
+      // Manual input from text field.
+      // Strip any leading '@' the user may have typed (the input field already
+      // shows '@' as a prefix, but copy-paste can introduce a duplicate).
+      if (normalizedUserId.startsWith('@')) {
+        normalizedUserId = normalizedUserId.substring(1);
+      }
       if (isCustomServer) {
         // For custom homeservers, expect full matrix ID without @ prefix
         // (since @ is already shown as prefix in the input field)


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#85

## What changed
- `add_friend_modal.dart` (`_addContact()`): strip any leading `@` from manually typed input before prepending it to build the full Matrix ID. This prevents `@@user:domain.com` being sent to `inviteUser()` when the user copy-pastes a full Matrix ID into the contact field.
- `room_service.dart` (`createGroup()`): same defensive strip on each `user` string in `userIds` before constructing `fullMatrixId`, ensuring the invite loop is robust even if a caller passes an ID that already has `@`.

## Why
On self-hosted / custom homeservers, pasting a full Matrix ID (e.g. `@john:myserver.io`) into the invite field caused the app to call `inviteUser("@@john:myserver.io")`, which the homeserver rejected as an invalid user ID, surfacing the "Invalid UserID" error the user reported.

## Risk
Low. Both changes are additive no-ops when the input has no `@` prefix (the normal case). The QR-scan path is unaffected because it enters a separate branch before the manual-input `@`-strip runs.

- [x] bug fix

**Release note:** Fixed "Invalid UserID" error when inviting users on self-hosted Matrix homeservers by stripping duplicate `@` prefix from pasted Matrix IDs.

_Agent-generated by the daily-issue-pipeline routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMiFgHzNqfXxCA66g9A6rL)_