### PR TITLE
fix: relabel status badges to show "moved X ago" instead of "X ago" (#90)

### DIFF
--- a/lib/widgets/contacts_subscreen.dart
+++ b/lib/widgets/contacts_subscreen.dart
@@ -770,17 +770,17 @@ class ContactsSubscreenState extends State<ContactsSubscreen> with TickerProvide
 
   String _getEnhancedStatusText(String timeAgo) {
     if (timeAgo == 'Just now') {
-      return 'Active now';
+      return 'Just moved';
     } else if (timeAgo.contains('s ago')) {
-      return 'Active now';
+      return 'Just moved';
     } else if (timeAgo.contains('m ago') && !timeAgo.contains('h')) {
-      return timeAgo;
+      return 'moved $timeAgo';
     } else if (timeAgo.contains('h ago')) {
-      return timeAgo;
+      return 'moved $timeAgo';
     } else if (timeAgo.contains('d ago')) {
-      return timeAgo;
+      return 'moved $timeAgo';
     } else {
-      return 'Offline';
+      return 'Off Grid';
     }
   }
 

--- a/lib/widgets/status_indictator.dart
+++ b/lib/widgets/status_indictator.dart
@@ -127,17 +127,17 @@ class StatusIndicator extends StatelessWidget {
 
   String _getEnhancedStatusText(String timeAgo) {
     if (timeAgo == 'Just now') {
-      return 'Active now';
+      return 'Just moved';
     } else if (timeAgo.contains('s ago')) {
-      return 'Active now';
+      return 'Just moved';
     } else if (timeAgo.contains('m ago') && !timeAgo.contains('h')) {
-      return timeAgo;
+      return 'moved $timeAgo';
     } else if (timeAgo.contains('h ago')) {
-      return timeAgo;
+      return 'moved $timeAgo';
     } else if (timeAgo.contains('d ago')) {
-      return timeAgo;
+      return 'moved $timeAgo';
     } else {
-      return 'Offline';
+      return 'Off Grid';
     }
   }
 }


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#90

## What changed
- `lib/widgets/status_indictator.dart` and `lib/widgets/contacts_subscreen.dart`: relabeled `_getEnhancedStatusText` return values so the timestamp is clearly framed as movement time:
  - "Active now" → "Just moved"
  - "5m ago" → "moved 5m ago"
  - "2h ago" → "moved 2h ago"
  - "Offline" → "Off Grid"

## Why
Users were confused because the app showed "40 min ago" next to a friend who was actively sharing location — the timestamp reflects the last time the user *moved*, not the last time a location update was received. Clarifying the label ("moved X ago") makes the meaning unambiguous without requiring a data-model change.

## Risk
Low — display-only change in two widget files with no logic or model modifications. The existing timestamp calculation is unchanged; only the rendered string is different.

- [x] bug fix
**Release note:** Status badges now show "moved X ago" instead of "X ago", making it clear the timestamp reflects movement rather than presence.

_Agent-generated by the daily-issue-pipeline routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMiFgHzNqfXxCA66g9A6rL)_