### PR TITLE
fix: replace NetworkTileProvider with CancellableTileProvider for satellite tiles

### DIFF
--- a/changes/pr-246.md
+++ b/changes/pr-246.md
@@ -1,0 +1,1 @@
+[fix] Fix map tile OOM crashes on rapid zoom by using cancellable tile provider for satellite layers

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:matrix/matrix.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:grid_frontend/repositories/sharing_preferences_repository.dart';
@@ -1732,7 +1733,7 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
                 else if (_currentMapStyle == 'satellite' && _satelliteMapToken != null)
                   TileLayer(
                     urlTemplate: '${dotenv.env['SAT_MAPS_URL'] ?? 'https://sat-maps.mygrid.app'}/tiles/alidade_satellite/{z}/{x}/{y}.png',
-                    tileProvider: NetworkTileProvider(
+                    tileProvider: CancellableTileProvider(
                       headers: {
                         'Authorization': 'Bearer $_satelliteMapToken',
                       },

--- a/lib/widgets/location_history_modal.dart
+++ b/lib/widgets/location_history_modal.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
@@ -928,7 +929,7 @@ class _LocationHistoryModalState extends State<LocationHistoryModal> {
                         else if (_currentMapStyle == 'satellite' && _satelliteMapToken != null)
                           TileLayer(
                             urlTemplate: '${dotenv.env['SAT_MAPS_URL'] ?? 'https://sat-maps.mygrid.app'}/tiles/alidade_satellite/{z}/{x}/{y}.png',
-                            tileProvider: NetworkTileProvider(
+                            tileProvider: CancellableTileProvider(
                               headers: {
                                 'Authorization': 'Bearer $_satelliteMapToken',
                               },


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#112

## What changed

- Replaced `NetworkTileProvider()` with `CancellableTileProvider()` for the satellite `TileLayer` in `lib/screens/map/map_tab.dart`
- Replaced `NetworkTileProvider()` with `CancellableTileProvider()` for the satellite `TileLayer` in `lib/widgets/location_history_modal.dart`
- Added the missing `flutter_map_cancellable_tile_provider` import to both files (the package was already declared in `pubspec.yaml`)

## Why

Users on devices like the Samsung S23+ reported the app slowing to a crawl and eventually crashing (apparent OOM) when zooming around on the satellite map layer. With `NetworkTileProvider`, every superseded tile request stays in-flight and continues consuming memory. `CancellableTileProvider` drops in-flight requests the moment a tile is no longer needed, preventing the tile-request queue from exhausting available memory.

## Risk

Minimal. `CancellableTileProvider` is a drop-in replacement for `NetworkTileProvider` and the package was already declared in `pubspec.yaml`. The vector tile layer (base map) is unchanged. Satellite tile display behaviour is identical under normal usage; only abandoned in-flight requests are handled differently (they are cancelled rather than completed and discarded).

- [x] `fix`

**Release note:** Fix map tile OOM crashes on rapid zoom by using cancellable tile provider for satellite layers

_Agent-generated by the daily-issue-pipeline routine._