### PR TITLE
fix: stop location tracking when app is backgrounded (#118)

### DIFF
--- a/lib/services/location_manager.dart
+++ b/lib/services/location_manager.dart
@@ -21,6 +21,9 @@ class LocationManager with ChangeNotifier {
   bool _batterySaverEnabled = false;
   bool _isMoving = false;
   DateTime? _lastLocationUpdate;
+  // True when tracking was paused by the background lifecycle handler (not by
+  // an explicit user action), so we know to resume it on foreground.
+  bool _pausedForBackground = false;
 
   late final AppLifecycleListener _lifecycleListener;
   StreamSubscription<LocationUpdate>? _locationSubscription;
@@ -42,10 +45,14 @@ class LocationManager with ChangeNotifier {
             _updateTrackingConfig();
             break;
           case AppLifecycleState.paused:
-          case AppLifecycleState.inactive:
-          case AppLifecycleState.detached:
+            // App is fully backgrounded — pause location updates.
             _isInForeground = false;
             _updateTrackingConfig();
+            break;
+          case AppLifecycleState.inactive:
+          case AppLifecycleState.detached:
+            // Transient states (notification shade, app switcher, pre-termination)
+            // — do not stop tracking here.
             break;
           default:
             break;
@@ -107,8 +114,25 @@ class LocationManager with ChangeNotifier {
     });
   }
 
-  // Apply the appropriate config based on battery-saver mode
+  // Apply the appropriate config based on battery-saver mode, and
+  // stop/resume tracking when the app is backgrounded/foregrounded.
   void _updateTrackingConfig() {
+    if (!_isInForeground) {
+      // App went to background — stop location polling to avoid draining battery.
+      if (_isTracking) {
+        _pausedForBackground = true;
+        stopTracking();
+      }
+      return;
+    }
+
+    // App is in foreground — resume if we paused it for the background.
+    if (_pausedForBackground && !_isTracking) {
+      _pausedForBackground = false;
+      startTracking();
+      return;
+    }
+
     if (!_isTracking) return;
 
     final mode = _batterySaverEnabled ? TrackingMode.batterySaver : TrackingMode.normal;
@@ -117,7 +141,7 @@ class LocationManager with ChangeNotifier {
       enableHeadless: true,
       startOnBoot: true,
     );
-    
+
     _locationService.setConfig(config);
   }
 


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#118

## What changed

- `LocationManager._updateTrackingConfig()` now stops the location service when the app enters `AppLifecycleState.paused` and restarts it when `AppLifecycleState.resumed` fires.
- A new `_pausedForBackground` flag tracks whether the stop was triggered by the lifecycle handler (so we only auto-resume if we auto-stopped, not if the user explicitly stopped).
- `AppLifecycleState.inactive` and `AppLifecycleState.detached` are no longer treated as "backgrounded" — they are transient states (notification shade, app switcher, pre-termination) that should not stop tracking.

## Why

When a user pressed the home button the location service kept running continuously because `_updateTrackingConfig()` only changed the tracking preset but never stopped the underlying service. This caused the location icon to remain in the status bar and drained battery on Android 15.

## Risk

- On resume, `startTracking()` re-calls `requestPermission()`, which on most devices returns immediately if already granted; no UX impact expected.
- If the user explicitly stops tracking via the UI and then backgrounds/foregrounds the app, `_pausedForBackground` stays `false` so the service is not incorrectly restarted — correct behavior preserved.

---

- [x] Bug fix
**Release note:** Reduce background battery drain by pausing location updates when app is not in foreground

_Agent-generated by the daily-issue-pipeline routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_0184GoWnKoef4Jn4dLyKCT9K)_