### PR TITLE
fix: remove Huawei Maven repository from android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://developer.huawei.com/repo/' }
         maven { url "https://storage.googleapis.com/download.flutter.io" }
     }
 }

--- a/changes/pr-249.md
+++ b/changes/pr-249.md
@@ -1,0 +1,1 @@
+[fix] Remove unused Huawei Maven repository URL that was incorrectly flagged by Exodus Privacy as an HMS tracker.


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#147

## What changed
- Removed the unused `https://developer.huawei.com/repo/` Maven repository URL from the `allprojects.repositories` block in `android/build.gradle`
- Confirmed no HMS dependency anywhere in the project references this URL

## Why
Exodus Privacy flags the Huawei developer Maven repository as a Huawei Mobile Services tracker, creating a false-positive privacy concern for users. The URL was declared with no corresponding HMS dependency, so removing it has no functional impact.

## Risk
Minimal. No HMS SDK or other dependency resolves artifacts from developer.huawei.com. If any transitive dependency somehow needed this repository, the build would fail with a clear unresolved-artifact error — a safe and visible failure mode.

- [x] `fix`

**Release note:** Remove unused Huawei Maven repository URL that was incorrectly flagged by Exodus Privacy as an HMS tracker.

_Agent-generated by the daily-issue-pipeline routine._