### PR TITLE
fix: set megolm rotation period on room creation to prevent per-event key rotation

### DIFF
--- a/changes/pr-250.md
+++ b/changes/pr-250.md
@@ -1,0 +1,1 @@
+[fix] Set megolm session rotation to 7 days / 100 messages on room creation so location events reuse the same encryption session instead of rotating per-event.

--- a/lib/services/room_service.dart
+++ b/lib/services/room_service.dart
@@ -132,7 +132,11 @@ class RoomService {
         initialState: [
           StateEvent(
             type: 'm.room.encryption',
-            content: {"algorithm": "m.megolm.v1.aes-sha2"},
+            content: {
+              "algorithm": "m.megolm.v1.aes-sha2",
+              "rotation_period_ms": 604800000,
+              "rotation_period_msgs": 100,
+            },
           ),
         ],
       );
@@ -593,7 +597,11 @@ class RoomService {
         initialState: [
           StateEvent(
             type: EventTypes.Encryption,
-            content: {'algorithm': 'm.megolm.v1.aes-sha2'},
+            content: {
+              'algorithm': 'm.megolm.v1.aes-sha2',
+              'rotation_period_ms': 604800000,
+              'rotation_period_msgs': 100,
+            },
           ),
           StateEvent(
             type: EventTypes.RoomPowerLevels,


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#138

## What changed
- Added `rotation_period_ms: 604800000` (7 days) and `rotation_period_msgs: 100` to the `m.room.encryption` state event content in `createRoomAndInviteContact` (direct rooms)
- Added the same rotation parameters to the `m.room.encryption` state event in `createGroup` (group rooms)

## Why
Each sent location event was triggering a new outbound megolm session because the `m.room.encryption` state event omitted `rotation_period_ms` and `rotation_period_msgs`. The Matrix SDK defaults to rotating the session on every sent event when these fields are absent, causing excessive key generation, key sharing to all devices, and increased network, battery, and disk usage.

## Risk
Low. This only affects newly created rooms; existing rooms retain their current (absent) rotation configuration. The values chosen (7 days / 100 messages) match the Matrix spec's recommended defaults. Decryption of existing messages is unaffected.

- [x] `fix`

**Release note:** Set megolm session rotation to 7 days / 100 messages on room creation so location events reuse the same encryption session instead of rotating per-event.

_Agent-generated by the daily-issue-pipeline routine._