### PR TITLE
fix: pad bottom sheet for Android virtual navigation bar

### DIFF
--- a/changes/pr-251.md
+++ b/changes/pr-251.md
@@ -1,0 +1,1 @@
+[fix] Fix Android virtual navigation bar overlapping the map bottom sheet on devices with on-screen nav buttons.

--- a/lib/widgets/map_scroll_window.dart
+++ b/lib/widgets/map_scroll_window.dart
@@ -287,7 +287,7 @@ class _MapScrollWindowState extends State<MapScrollWindow>
                           notification is ScrollUpdateNotification &&
                           notification.dragDetails != null &&
                           !_isScrollingContent) {
-                        final delta = notification.dragDetails!.delta.dy / 
+                        final delta = notification.dragDetails!.delta.dy /
                             MediaQuery.of(context).size.height;
                         final newSize = (_scrollableController.size - delta)
                             .clamp(0.3, 0.7);
@@ -299,6 +299,9 @@ class _MapScrollWindowState extends State<MapScrollWindow>
                     child: _buildSubscreen(scrollController),
                   ),
                 ),
+                // Reserve space for the Android system navigation bar so
+                // the sheet content is not drawn behind the virtual buttons.
+                SizedBox(height: MediaQuery.of(context).padding.bottom),
               ],
             ),
           ),

--- a/lib/widgets/map_scroll_window.dart
+++ b/lib/widgets/map_scroll_window.dart
@@ -287,7 +287,7 @@ class _MapScrollWindowState extends State<MapScrollWindow>
                           notification is ScrollUpdateNotification &&
                           notification.dragDetails != null &&
                           !_isScrollingContent) {
-                        final delta = notification.dragDetails!.delta.dy /
+                        final delta = notification.dragDetails!.delta.dy / 
                             MediaQuery.of(context).size.height;
                         final newSize = (_scrollableController.size - delta)
                             .clamp(0.3, 0.7);
@@ -299,8 +299,6 @@ class _MapScrollWindowState extends State<MapScrollWindow>
                     child: _buildSubscreen(scrollController),
                   ),
                 ),
-                // Reserve space for the Android system navigation bar so
-                // the sheet content is not drawn behind the virtual buttons.
                 SizedBox(height: MediaQuery.of(context).padding.bottom),
               ],
             ),


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#152

## What changed
- Added `SizedBox(height: MediaQuery.of(context).padding.bottom)` at the bottom of the `Column` inside the `DraggableScrollableSheet` builder in `lib/widgets/map_scroll_window.dart`.

## Why
On Android devices with virtual (gesture or button) navigation bars, the system reports a non-zero `MediaQuery.padding.bottom` inset. The `DraggableScrollableSheet` was placed with `Alignment.bottomCenter` in `map_tab.dart` without compensating for this inset, causing the Android navigation bar to render on top of the bottom sheet content.

## Risk
- On devices without a virtual navigation bar (hardware buttons, or full-gesture nav with zero inset) `MediaQuery.padding.bottom` is 0, so there is no visible change on those devices.
- On affected Android devices the sheet content shifts up by the navigation bar height — the desired behaviour.

- [x] `fix`

**Release note:** Fix Android virtual navigation bar overlapping the map bottom sheet on devices with on-screen nav buttons.

_Agent-generated by the daily-issue-pipeline routine._