### PR TITLE
fix: background location updates silently dropped and ping countdown frozen (#153)

### DIFF
--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -2238,7 +2238,7 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
                                 width: 24,
                                 height: 24,
                                 child: CircularProgressIndicator(
-                                  value: _pingCooldownSeconds / 5,
+                                  value: _pingCooldownSeconds / 10,
                                   strokeWidth: 2,
                                   color: isDarkMode ? colorScheme.primary : Colors.black,
                                   backgroundColor: isDarkMode ? colorScheme.surfaceVariant : Colors.grey.withOpacity(0.3),

--- a/lib/services/android_background_task.dart
+++ b/lib/services/android_background_task.dart
@@ -191,8 +191,8 @@ Future<bool> _checkSharingWindow(Room room, List<User> joinedMembers, Client cli
 }
 
 Future<void> _sendLocationUpdate(Room room, double latitude, double longitude, double accuracy) async {
-  // Filter out low-accuracy locations to save battery and improve quality
-  if (accuracy > 100) {
+  // Filter out extremely low-accuracy locations only; 500m allows urban/indoor fixes
+  if (accuracy > 500) {
     print("Grid: ⚠️  Skipping low-accuracy location for ${room.name}: ${accuracy.toStringAsFixed(1)}m error");
     return;
   }


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#153

## What changed
- Raised the GPS accuracy filter in `android_background_task.dart` from 100 m to 500 m so that urban and indoor fixes (which commonly report 100–300 m accuracy) are no longer silently discarded during background location updates.
- Fixed the ping `CircularProgressIndicator` value in `map_tab.dart`: changed the divisor from `5` to `10` to match the 10-second cooldown, preventing the indicator from clamping at 1.0 (appearing frozen) for the first 5 seconds of the countdown.

## Why
Users on Android 14 with all permissions granted reported that location updates only arrived when the app was open, and the ping button countdown appeared stuck. The 100 m accuracy threshold rejected most background fixes on typical devices, and the progress bar was visually broken due to an off-by-one divisor against the actual cooldown duration.

## Risk
Raising the accuracy threshold to 500 m will allow lower-quality fixes through; in poor signal environments this may briefly show a less precise location. The ping progress fix is cosmetic only and carries no functional risk.

- [x] `fix`

**Release note:** Fix background location updates being silently dropped on Android and fix ping countdown progress indicator appearing frozen.

_Agent-generated by the daily-issue-pipeline routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1t3SYWZdCk8wuGTfUPVQX)_