### PR TITLE
fix: generate missing IV in insertLocation so peer location messages are saved (#156)

### DIFF
--- a/lib/blocs/contacts/contacts_bloc.dart
+++ b/lib/blocs/contacts/contacts_bloc.dart
@@ -162,11 +162,12 @@ class ContactsBloc extends Bloc<ContactsEvent, ContactsState> {
         print("ContactsBloc: No direct room found for contact ${contact.userId}");
       }
       
+      final lastSeenTimestamp = userLocationProvider.getLastSeen(contact.userId);
       contactDisplays.add(ContactDisplay(
         userId: contact.userId,
         displayName: contact.displayName ?? 'Deleted User',
         avatarUrl: contact.avatarUrl,
-        lastSeen: 'Offline',
+        lastSeen: lastSeenTimestamp ?? 'Offline',
         membershipStatus: membershipStatus,
       ));
     }

--- a/lib/repositories/location_repository.dart
+++ b/lib/repositories/location_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:encrypt/encrypt.dart' as encrypt;
 import 'package:sqflite/sqflite.dart';
 import 'package:grid_frontend/models/user_location.dart';
 import 'package:grid_frontend/services/database_service.dart';
@@ -30,13 +31,23 @@ class LocationRepository {
   Future<void> insertLocation(UserLocation location) async {
     final db = await _databaseService.database;
     final encryptionKey = await _databaseService.getEncryptionKey();
+    // Generate a fresh IV when the caller did not supply one.
+    final effective = location.iv.isEmpty
+        ? UserLocation(
+            userId: location.userId,
+            latitude: location.latitude,
+            longitude: location.longitude,
+            timestamp: location.timestamp,
+            iv: encrypt.IV.fromSecureRandom(16).base64,
+          )
+        : location;
     await db.insert(
       'UserLocations',
-      location.toMap(encryptionKey),
+      effective.toMap(encryptionKey),
       conflictAlgorithm: ConflictAlgorithm.replace,
     );
     // Notify that a location was updated
-    _locationUpdatesController.add(location);
+    _locationUpdatesController.add(effective);
   }
 
   /// Delete all location data for a specific user


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#156

## What changed
- `lib/repositories/location_repository.dart`: added `package:encrypt/encrypt.dart` import and updated `insertLocation` to generate a cryptographically secure random IV (16 bytes) when the caller supplies an empty `iv` string, then uses the effective `UserLocation` for both the database write and the stream notification.
- `lib/blocs/contacts/contacts_bloc.dart`: `_loadContacts()` was hardcoding `lastSeen: 'Offline'` for every contact; now reads the real cached timestamp from `UserLocationProvider` so the emitted `ContactDisplay` reflects actual presence data.

## Why
Incoming `m.location` events from iOS peers were constructed in `MessageProcessor._handleLocationMessageIfAny` with `iv: ''`. When `UserLocation.toMap` called `encrypt.IV.fromBase64('')` it threw a `FormatException`, which was silently swallowed by the catch-block in `_processRoomMessages`. The location was never written to the database, `UserLocationProvider` was never notified, and every peer appeared permanently "Offline" on Android — while those same peers could see the Android user online (because the Android user's own outgoing location flow generates a proper IV). The contacts bloc also independently hardcoded "Offline" as default even when cached location data was available.

## Risk
Low. The IV-generation change only affects the path where `iv.isEmpty` is true, which previously always threw. All existing callers that already supply a valid IV are unaffected. The contacts-bloc change is additive — the same `getLastSeen` call was already being made in the contacts subscreen widget.

- [x] Bug fix

**Release note:** Fix Android users seeing all friends as Offline by generating a valid encryption IV for incoming peer location messages.

_Agent-generated by the daily-issue-pipeline routine._