### PR TITLE
fix: request missing Megolm session key to restore iOS to Android location sync (#156)

### DIFF
--- a/changes/pr-256.md
+++ b/changes/pr-256.md
@@ -1,1 +1,1 @@
-[fix] Fixed Android contacts always showing "Offline" — location messages from iOS peers are now properly requested and decrypted
+[fix] Fixed Android contacts always showing Offline — location messages from iOS peers are now properly requested and decrypted

--- a/changes/pr-256.md
+++ b/changes/pr-256.md
@@ -1,0 +1,1 @@
+[fix] Fixed Android contacts always showing "Offline" — location messages from iOS peers are now properly requested and decrypted

--- a/lib/services/message_processor.dart
+++ b/lib/services/message_processor.dart
@@ -73,11 +73,30 @@ class MessageProcessor {
     }
     final Event decryptedEvent = await enc.decryptRoomEvent(finalEvent);
 
-    // Check for decryption failure
-    if (decryptedEvent.type == 'm.room.encrypted' &&
-        decryptedEvent.content['msgtype'] == 'm.bad.encrypted') {
-      print('[MessageProcessor] ⚠️ DECRYPTION FAILED for event from ${finalEvent.senderId}');
+    // Check for decryption failure — covers both the explicit m.bad.encrypted
+    // msgtype and the silent case where the SDK leaves the event as
+    // m.room.encrypted without setting that msgtype (e.g. missing Megolm session
+    // on Android when receiving from an iOS peer for the first time).
+    if (decryptedEvent.type == 'm.room.encrypted') {
+      final badEncrypted = decryptedEvent.content['msgtype'] == 'm.bad.encrypted';
+      print('[MessageProcessor] ⚠️ DECRYPTION FAILED for event from ${finalEvent.senderId}'
+          '${badEncrypted ? " (m.bad.encrypted)" : " (session key not available)"}');
       _onDecryptionError?.call(finalEvent.senderId ?? 'unknown', roomId);
+
+      // Request the missing Megolm session key from the sender's other devices
+      // so that subsequent location events from iOS peers can be decrypted.
+      try {
+        final sessionId = finalEvent.content['session_id'] as String?;
+        final senderKey = finalEvent.content['sender_key'] as String?;
+        if (sessionId != null) {
+          print('[MessageProcessor] Requesting missing session key $sessionId from room $roomId');
+          await enc.keyManager.request(room, sessionId, senderKey);
+        }
+      } catch (e) {
+        print('[MessageProcessor] Key request failed (non-fatal): $e');
+      }
+
+      return null;
     }
 
     // Check if the decrypted event is now a message


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#156

## What changed
- Extended the decryption failure guard in `MessageProcessor.processEvent` to catch both explicit `m.bad.encrypted` events and the silent case where the SDK leaves an event typed as `m.room.encrypted` after a failed Megolm decrypt
- After any decryption failure, extracts `session_id` and `sender_key` from the original encrypted event content and calls `enc.keyManager.request(room, sessionId, senderKey)` to trigger a Matrix room-key request to the sender's other devices
- Added explicit `return null` after detecting any decryption failure to prevent processing undecrypted content
- Key-request errors are caught and logged as non-fatal so they cannot interrupt the sync loop

## Why
Android users saw all their friends as "Offline" and could not see their locations, while iOS users could see the Android user as "Online". When an Android client first receives an encrypted event from an iOS peer, it may lack the Megolm session key. The SDK silently fails decryption (event stays typed as `m.room.encrypted`); the old code only guarded against the explicit `m.bad.encrypted` msgtype, so silent failures were invisible and no key request was ever sent. Without a key request, the Android device never recovered the session key, and every subsequent location event from iOS peers failed to decrypt — leaving all contacts permanently "Offline".

## Risk
- `keyManager.request()` is a no-op if the session key is already present, so there is no regression for events that decrypt successfully
- The `try/catch` wrapping the key request means a bad SDK call cannot break the sync loop
- The explicit `return null` on decryption failure matches the effective prior behavior for silent failures (they fell through to the final `return null`), so no externally observable behavior changes for those events
- iOS users are unaffected (they already had the session keys)

---

- [x] `fix`

**Release note:**
Fixed Android contacts always showing "Offline" — location messages from iOS peers are now properly requested and decrypted

_Agent-generated by the daily-issue-pipeline routine._