### PR TITLE
fix: exponential backoff for sync stream errors to prevent data/battery drain

### DIFF
--- a/changes/pr-258.md
+++ b/changes/pr-258.md
@@ -1,1 +1,1 @@
-[fix] Fixed data and battery drain caused by infinite retry loop when the home server is unreachable
+[fix] Add exponential backoff (2 s to 5 min cap) to the sync-stream error handler so the app stops retrying indefinitely against an offline server.

--- a/changes/pr-258.md
+++ b/changes/pr-258.md
@@ -1,0 +1,1 @@
+[fix] Fixed data and battery drain caused by infinite retry loop when the home server is unreachable

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -319,22 +319,49 @@ class SyncManager with ChangeNotifier {
 
 
   StreamSubscription<SyncUpdate>? _syncSubscription;
-  
+
+  // Exponential backoff state for sync stream errors
+  int _syncErrorCount = 0;
+  static const int _maxSyncBackoffSeconds = 300; // cap at 5 minutes
+  static const int _syncBackoffBaseSeconds = 2;
+
   Future<void> _startSyncStream() async {
     if (_syncSubscription != null) return;
-    
+
     _syncSubscription = client.onSync.stream.listen(
       (syncUpdate) async {
+        // Successful sync: reset error counter
+        _syncErrorCount = 0;
         await _processSyncUpdate(syncUpdate);
       },
-      onError: (error) {
+      onError: (error) async {
         print("Sync stream error: $error");
         if (_isAuthenticationError(error)) {
           _handleAuthenticationFailure();
+          return;
+        }
+
+        // Non-auth error (e.g. server offline): apply exponential backoff before
+        // allowing the stream to be restarted, preventing a hot retry loop.
+        _syncErrorCount++;
+        final delaySecs = (_syncBackoffBaseSeconds * (1 << (_syncErrorCount - 1)))
+            .clamp(0, _maxSyncBackoffSeconds);
+        print("[SyncManager] Sync error #$_syncErrorCount, backing off ${delaySecs}s before retry");
+
+        // Cancel the current subscription so _startSyncStream can be called again.
+        _syncSubscription?.cancel();
+        _syncSubscription = null;
+
+        await Future.delayed(Duration(seconds: delaySecs));
+
+        // Only restart if the manager is still active and the user is logged in.
+        if (_isActive && client.isLogged() && !_authenticationFailed) {
+          print("[SyncManager] Retrying sync stream after backoff");
+          await _startSyncStream();
         }
       },
     );
-    
+
     // Check if the client is already syncing before starting a new sync
     if (!client.syncPending) {
       _isSyncing = true;
@@ -391,11 +418,12 @@ class SyncManager with ChangeNotifier {
 
   Future<void> stopSync() async {
     if (!_isSyncing && !client.syncPending) return;
-    
+
     _isSyncing = false;
+    _syncErrorCount = 0;
     _syncSubscription?.cancel();
     _syncSubscription = null;
-    
+
     if (client.syncPending) {
       client.abortSync();
     }
@@ -423,6 +451,7 @@ class SyncManager with ChangeNotifier {
     _pendingMessages.clear();
     _isInitialized = false;
     _isSyncing = false;
+    _syncErrorCount = 0;
 
     // Clear the sync token so next login does a full sync
     _sinceToken = null;

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -344,7 +344,8 @@ class SyncManager with ChangeNotifier {
         // Non-auth error (e.g. server offline): apply exponential backoff before
         // allowing the stream to be restarted, preventing a hot retry loop.
         _syncErrorCount++;
-        final delaySecs = (_syncBackoffBaseSeconds * (1 << (_syncErrorCount - 1)))
+        final shiftBy = (_syncErrorCount - 1).clamp(0, 7);
+        final delaySecs = (_syncBackoffBaseSeconds * (1 << shiftBy))
             .clamp(0, _maxSyncBackoffSeconds);
         print("[SyncManager] Sync error #$_syncErrorCount, backing off ${delaySecs}s before retry");
 


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#230

## What changed
- Added `_syncErrorCount`, `_maxSyncBackoffSeconds` (300 s), and `_syncBackoffBaseSeconds` (2 s) fields to `SyncManager`.
- The `onError` callback in `_startSyncStream()` now cancels the subscription, waits `2^(n-1) * 2` seconds (capped at 5 min) after the nth consecutive failure, then re-calls `_startSyncStream()` — only when the app is active and the user is still logged in.
- Successful sync updates reset `_syncErrorCount` to 0 so backoff starts fresh after recovery.
- `stopSync()` and `clearAllState()` also reset `_syncErrorCount` to keep a manual stop/restart and fresh login clean.

## Why
When the user's self-hosted Matrix Synapse backend goes offline, the sync-stream error handler logged the error and returned immediately with no delay, letting the Matrix client retry in a tight loop. Over ~10 hours on a Google Pixel 9 Pro XL (Android 16) this consumed 31+ GB of mobile data and drained the battery.

## Risk
- The delay slows reconnection after a brief blip, but `_syncErrorCount` resets on the first successful sync so steady-state operation is unchanged.
- Auth-error path is untouched; M_UNKNOWN_TOKEN still triggers immediate logout.
- No callers outside `_startSyncStream` / `stopSync` / `clearAllState` are affected.

---

- [x] `fix`

**Release note:**
Add exponential backoff (2 s to 5 min cap) to the sync-stream error handler so the app stops retrying indefinitely against an offline server.

_Agent-generated by the daily-issue-pipeline routine._