### PR TITLE
Weekly agent rollup: week of 2026-05-18

### DIFF
--- a/changes/pr-256.md
+++ b/changes/pr-256.md
@@ -1,0 +1,1 @@
+[fix] Fixed Android contacts always showing Offline — location messages from iOS peers are now properly requested and decrypted

--- a/changes/pr-257.md
+++ b/changes/pr-257.md
@@ -1,0 +1,1 @@
+[fix] Add Sign up with SMS instead fallback on the signup screen for devices where passkey creation is unavailable.

--- a/changes/pr-258.md
+++ b/changes/pr-258.md
@@ -1,0 +1,1 @@
+[fix] Add exponential backoff (2 s to 5 min cap) to the sync-stream error handler so the app stops retrying indefinitely against an offline server.

--- a/lib/screens/onboarding/server_select_screen.dart
+++ b/lib/screens/onboarding/server_select_screen.dart
@@ -631,6 +631,22 @@ class _ServerSelectScreenState extends State<ServerSelectScreen> with TickerProv
         const SizedBox(height: 16),
 
         _buildModernButton(
+          text: 'Sign up with SMS instead',
+          onPressed: _usernameStatusMessage == 'Username is available'
+              ? () {
+                  setState(() {
+                    _currentStep = 1;
+                  });
+                  _animateToNextStep();
+                }
+              : null,
+          isPrimary: false,
+          icon: Icons.sms,
+        ),
+
+        const SizedBox(height: 16),
+
+        _buildModernButton(
           text: 'Already have an account? Sign In',
           onPressed: () {
             setState(() {

--- a/lib/services/message_processor.dart
+++ b/lib/services/message_processor.dart
@@ -73,11 +73,30 @@ class MessageProcessor {
     }
     final Event decryptedEvent = await enc.decryptRoomEvent(finalEvent);
 
-    // Check for decryption failure
-    if (decryptedEvent.type == 'm.room.encrypted' &&
-        decryptedEvent.content['msgtype'] == 'm.bad.encrypted') {
-      print('[MessageProcessor] ⚠️ DECRYPTION FAILED for event from ${finalEvent.senderId}');
+    // Check for decryption failure — covers both the explicit m.bad.encrypted
+    // msgtype and the silent case where the SDK leaves the event as
+    // m.room.encrypted without setting that msgtype (e.g. missing Megolm session
+    // on Android when receiving from an iOS peer for the first time).
+    if (decryptedEvent.type == 'm.room.encrypted') {
+      final badEncrypted = decryptedEvent.content['msgtype'] == 'm.bad.encrypted';
+      print('[MessageProcessor] ⚠️ DECRYPTION FAILED for event from ${finalEvent.senderId}'
+          '${badEncrypted ? " (m.bad.encrypted)" : " (session key not available)"}');
       _onDecryptionError?.call(finalEvent.senderId ?? 'unknown', roomId);
+
+      // Request the missing Megolm session key from the sender's other devices
+      // so that subsequent location events from iOS peers can be decrypted.
+      try {
+        final sessionId = finalEvent.content['session_id'] as String?;
+        final senderKey = finalEvent.content['sender_key'] as String?;
+        if (sessionId != null) {
+          print('[MessageProcessor] Requesting missing session key $sessionId from room $roomId');
+          await enc.keyManager.request(room, sessionId, senderKey);
+        }
+      } catch (e) {
+        print('[MessageProcessor] Key request failed (non-fatal): $e');
+      }
+
+      return null;
     }
 
     // Check if the decrypted event is now a message

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -319,22 +319,49 @@ class SyncManager with ChangeNotifier {
 
 
   StreamSubscription<SyncUpdate>? _syncSubscription;
-  
+
+  // Exponential backoff state for sync stream errors
+  int _syncErrorCount = 0;
+  static const int _maxSyncBackoffSeconds = 300; // cap at 5 minutes
+  static const int _syncBackoffBaseSeconds = 2;
+
   Future<void> _startSyncStream() async {
     if (_syncSubscription != null) return;
-    
+
     _syncSubscription = client.onSync.stream.listen(
       (syncUpdate) async {
+        // Successful sync: reset error counter
+        _syncErrorCount = 0;
         await _processSyncUpdate(syncUpdate);
       },
-      onError: (error) {
+      onError: (error) async {
         print("Sync stream error: $error");
         if (_isAuthenticationError(error)) {
           _handleAuthenticationFailure();
+          return;
+        }
+
+        // Non-auth error (e.g. server offline): apply exponential backoff before
+        // allowing the stream to be restarted, preventing a hot retry loop.
+        _syncErrorCount++;
+        final delaySecs = (_syncBackoffBaseSeconds * (1 << (_syncErrorCount - 1)))
+            .clamp(0, _maxSyncBackoffSeconds);
+        print("[SyncManager] Sync error #$_syncErrorCount, backing off ${delaySecs}s before retry");
+
+        // Cancel the current subscription so _startSyncStream can be called again.
+        _syncSubscription?.cancel();
+        _syncSubscription = null;
+
+        await Future.delayed(Duration(seconds: delaySecs));
+
+        // Only restart if the manager is still active and the user is logged in.
+        if (_isActive && client.isLogged() && !_authenticationFailed) {
+          print("[SyncManager] Retrying sync stream after backoff");
+          await _startSyncStream();
         }
       },
     );
-    
+
     // Check if the client is already syncing before starting a new sync
     if (!client.syncPending) {
       _isSyncing = true;
@@ -391,11 +418,12 @@ class SyncManager with ChangeNotifier {
 
   Future<void> stopSync() async {
     if (!_isSyncing && !client.syncPending) return;
-    
+
     _isSyncing = false;
+    _syncErrorCount = 0;
     _syncSubscription?.cancel();
     _syncSubscription = null;
-    
+
     if (client.syncPending) {
       client.abortSync();
     }
@@ -423,6 +451,7 @@ class SyncManager with ChangeNotifier {
     _pendingMessages.clear();
     _isInitialized = false;
     _isSyncing = false;
+    _syncErrorCount = 0;
 
     // Clear the sync token so next login does a full sync
     _sinceToken = null;

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -344,7 +344,8 @@ class SyncManager with ChangeNotifier {
         // Non-auth error (e.g. server offline): apply exponential backoff before
         // allowing the stream to be restarted, preventing a hot retry loop.
         _syncErrorCount++;
-        final delaySecs = (_syncBackoffBaseSeconds * (1 << (_syncErrorCount - 1)))
+        final shiftBy = (_syncErrorCount - 1).clamp(0, 7);
+        final delaySecs = (_syncBackoffBaseSeconds * (1 << shiftBy))
             .clamp(0, _maxSyncBackoffSeconds);
         print("[SyncManager] Sync error #$_syncErrorCount, backing off ${delaySecs}s before retry");
 


### PR DESCRIPTION
## Summary — week of 2026-05-18 (Grid-Mobile)

Merged this week (3):
- Rezivure/Grid-Mobile#256 — fix: request missing Megolm session key to restore iOS to Android location sync _(addresses Grid-Mobile#156)_
- Rezivure/Grid-Mobile#257 — fix: add SMS fallback to signup flow for devices without passkey support _(addresses Grid-Mobile#254)_
- Rezivure/Grid-Mobile#258 — fix: exponential backoff for sync stream errors to prevent data/battery drain _(addresses Grid-Mobile#230)_

## Test plan

- [ ] Skim each merged PR's diff via the "Files changed" tab on this rollup PR.
- [ ] CI already ran per individual PR; this rollup re-runs CI on the combined diff.
- [ ] Merge this PR to ship the week into `main`.

_Generated by `.claude/routines/weekly-consolidate.md` on 2026-05-22. Agent-managed branch: `agent/week-of-2026-05-18`._

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpGZJEL2CnDGYaQFhp466a)_