### PR TITLE
fix(map): revert camera guard — strict resumed-only (ship 820)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           export PATH="/opt/homebrew/bin:$PATH"
           VERSION_NAME=$(grep '^version:' pubspec.yaml | sed 's/version: *//;s/+.*//')
-          BUILD_NUMBER=$(( ${{ github.run_number }} + 709 ))
+          BUILD_NUMBER=$(( ${{ github.run_number }} + 784 ))
           sed -i '' "s/^version: .*/version: ${VERSION_NAME}+${BUILD_NUMBER}/" pubspec.yaml
           echo "📦 Release version: ${VERSION_NAME}+${BUILD_NUMBER}"
           echo "version=${VERSION_NAME}+${BUILD_NUMBER}" >> $GITHUB_OUTPUT

--- a/changes/pr-265.md
+++ b/changes/pr-265.md
@@ -1,0 +1,1 @@
+[fix] Fix cold-launch crash that hit TestFlight build 744. Map may not auto-center on first open; tap the locate button to recenter.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -330,11 +330,16 @@ void main() async {
               final messageProcessor = MessageProcessor(
                 locationRepository,
                 locationHistoryRepository,
-                messageParser, 
+                messageParser,
                 client,
                 avatarBloc: context.read<AvatarBloc>(),
                 mapIconSyncService: mapIconSyncService,
                 roomLocationHistoryRepository: roomLocationHistoryRepository,
+                userRepository: userRepository,
+                sharingPreferencesRepository: sharingPreferencesRepository,
+                userService: userService,
+                locationManager: context.read<LocationManager>(),
+                roomService: roomService,
               );
               return SyncManager(
                 client,
@@ -355,7 +360,7 @@ void main() async {
             },
             update: (context, avatarBloc, mapBloc, contactsBloc, groupsBloc, invitationsBloc, previous) {
               if (previous != null) return previous;
-              
+
               // Create MapIconSyncService
               final mapIconRepository = MapIconRepository(databaseService);
               final mapIconSyncService = MapIconSyncService(
@@ -363,15 +368,20 @@ void main() async {
                 mapIconRepository: mapIconRepository,
                 mapIconsBloc: context.read<MapIconsBloc>(),
               );
-              
+
               final messageProcessor = MessageProcessor(
                 locationRepository,
                 locationHistoryRepository,
-                messageParser, 
+                messageParser,
                 client,
                 avatarBloc: avatarBloc,
                 mapIconSyncService: mapIconSyncService,
                 roomLocationHistoryRepository: roomLocationHistoryRepository,
+                userRepository: userRepository,
+                sharingPreferencesRepository: sharingPreferencesRepository,
+                userService: userService,
+                locationManager: context.read<LocationManager>(),
+                roomService: roomService,
               );
               return SyncManager(
                 client,

--- a/lib/screens/map/maplibre_camera_facade.dart
+++ b/lib/screens/map/maplibre_camera_facade.dart
@@ -81,14 +81,13 @@ class MaplibreCameraFacade {
     ));
   }
 
-  // Skip moves only when actually backgrounded. The cold-launch `inactive`
-  // window has a valid-size view, so it's safe — gating on `== resumed` instead
-  // dropped the first auto-recenter and left the map stuck until the next
-  // location update arrived.
-  bool get _foregrounded {
-    final s = WidgetsBinding.instance.lifecycleState;
-    return s != AppLifecycleState.paused && s != AppLifecycleState.hidden;
-  }
+  // Only allow moves when fully resumed. The transient `inactive` / `detached`
+  // states on cold-launch and resume have a not-yet-laid-out MLNMapView; running
+  // the bounds-clamp against a zero-size layer NaNs out and throws an uncaught
+  // C++ exception in the native LatLng ctor (SIGABRT). A dropped move is ugly
+  // (no dot until the next location update) but recoverable; a crash is not.
+  bool get _foregrounded =>
+      WidgetsBinding.instance.lifecycleState == AppLifecycleState.resumed;
 
   double _safeZoom(double zoom) {
     if (zoom.isNaN || zoom.isInfinite) return 2.0;

--- a/lib/services/avatar_announcement_service.dart
+++ b/lib/services/avatar_announcement_service.dart
@@ -290,26 +290,79 @@ class AvatarAnnouncementService {
     }
   }
 
-  /// Handle incoming avatar request and respond with our avatar
-  Future<void> handleAvatarRequest(String roomId, String requesterId, List<String>? requestedUsers) async {
+  /// Handle incoming avatar request and respond with our avatar. Returns
+  /// true if we have an avatar and announced it, false if we sent an
+  /// `m.avatar.absent` reply because no avatar is configured locally.
+  Future<bool> handleAvatarRequest(String roomId, String requesterId, List<String>? requestedUsers) async {
     try {
       final myUserId = client.userID;
-      if (myUserId == null) return;
+      if (myUserId == null) return false;
 
       // Check if we're in the requested users list (or if it's a broadcast request)
       if (requestedUsers != null && !requestedUsers.contains(myUserId)) {
-        return; // Request not for us
+        return false; // Request not for us
       }
 
       // Don't respond to our own requests
-      if (requesterId == myUserId) return;
+      if (requesterId == myUserId) return false;
+
+      // If we have no avatar configured, tell the requester so they back off
+      // their cooldown instead of asking again in 24h.
+      final avatarDataStr = await secureStorage.read(key: 'avatar_$myUserId');
+      if (avatarDataStr == null) {
+        print('[Avatar Request] No local avatar; sending m.avatar.absent to $requesterId');
+        await _announceAvatarAbsent(roomId);
+        return false;
+      }
 
       print('[Avatar Request] Responding to avatar request from $requesterId in room $roomId');
-      
-      // Send our avatar announcement
       await announceProfPicToRoom(roomId);
+      return true;
     } catch (e) {
       print('[Avatar Request] Error handling request: $e');
+      return false;
+    }
+  }
+
+  /// Notify the room that we have no avatar set so requesters can record
+  /// the absence and extend their cooldown.
+  Future<void> _announceAvatarAbsent(String roomId) async {
+    try {
+      final room = client.getRoomById(roomId);
+      if (room == null || room.membership != Membership.join) return;
+      final eventContent = {
+        'msgtype': 'm.avatar.absent',
+        'body': 'No avatar set',
+        'timestamp': DateTime.now().toUtc().toIso8601String(),
+      };
+      await room.sendEvent(eventContent);
+    } catch (e) {
+      print('[Avatar Absent] Error sending absence to room $roomId: $e');
+    }
+  }
+
+  /// Request location updates from specific users (or all room members).
+  /// Mirrors [requestAvatars]; the response is a regular `m.location` ping
+  /// from the recipient(s).
+  Future<void> requestLocations(String roomId, {List<String>? userIds}) async {
+    try {
+      final room = client.getRoomById(roomId);
+      if (room == null || room.membership != Membership.join) {
+        print('[Location Request] Skipping room $roomId - not a member');
+        return;
+      }
+
+      final eventContent = {
+        'msgtype': 'm.location.request',
+        'body': 'Requesting location update',
+        'requested_users': userIds,
+        'timestamp': DateTime.now().toUtc().toIso8601String(),
+      };
+
+      await room.sendEvent(eventContent);
+      print('[Location Request] Sent location request to room ${room.name} ($roomId) for users: ${userIds?.join(", ") ?? "all"}');
+    } catch (e) {
+      print('[Location Request] Error sending request to room $roomId: $e');
     }
   }
 }

--- a/lib/services/message_processor.dart
+++ b/lib/services/message_processor.dart
@@ -20,6 +20,12 @@ import 'package:grid_frontend/blocs/avatar/avatar_bloc.dart';
 import 'package:grid_frontend/blocs/avatar/avatar_event.dart';
 import 'package:grid_frontend/services/map_icon_sync_service.dart';
 import 'package:grid_frontend/services/avatar_announcement_service.dart';
+import 'package:grid_frontend/services/request_cooldown_service.dart';
+import 'package:grid_frontend/services/location_manager.dart';
+import 'package:grid_frontend/services/user_service.dart';
+import 'package:grid_frontend/services/room_service.dart';
+import 'package:grid_frontend/repositories/user_repository.dart';
+import 'package:grid_frontend/repositories/sharing_preferences_repository.dart';
 
 /// Callback type for decryption errors
 typedef DecryptionErrorCallback = void Function(String senderId, String roomId);
@@ -33,6 +39,12 @@ class MessageProcessor {
   final FlutterSecureStorage secureStorage = FlutterSecureStorage();
   final AvatarBloc? avatarBloc;
   final MapIconSyncService? mapIconSyncService;
+  final UserRepository? userRepository;
+  final SharingPreferencesRepository? sharingPreferencesRepository;
+  final UserService? userService;
+  final LocationManager? locationManager;
+  final RoomService? roomService;
+  final RequestCooldownService _cooldown = RequestCooldownService();
 
   /// Callback for when decryption fails
   DecryptionErrorCallback? _onDecryptionError;
@@ -44,7 +56,12 @@ class MessageProcessor {
       this.client,
       {this.avatarBloc,
       this.mapIconSyncService,
-      this.roomLocationHistoryRepository}
+      this.roomLocationHistoryRepository,
+      this.userRepository,
+      this.sharingPreferencesRepository,
+      this.userService,
+      this.locationManager,
+      this.roomService}
       );
 
   /// Use the client's encryption instance which has the actual keys
@@ -109,6 +126,8 @@ class MessageProcessor {
         await _handleAvatarState(messageData);
       } else if (msgType == 'm.avatar.request') {
         await _handleAvatarRequest(messageData, roomId);
+      } else if (msgType == 'm.location.request') {
+        await _handleLocationRequest(messageData, roomId);
       } else if (_isMapIconEvent(msgType)) {
         // Handle map icon events
         await _handleMapIconEvent(roomId, messageData);
@@ -449,6 +468,60 @@ class MessageProcessor {
       print('[Avatar State] Finished processing ${avatarsList.length} avatars from state bundle');
     } catch (e) {
       print('[Avatar State] Error handling avatar state: $e');
+    }
+  }
+
+  /// Handle incoming location request — respond with a fresh ping if the
+  /// sender is a known contact, sharing is on, we're in the sharing window,
+  /// and we haven't already answered them recently.
+  Future<void> _handleLocationRequest(Map<String, dynamic> messageData, String roomId) async {
+    try {
+      final sender = messageData['sender'] as String?;
+      final content = messageData['content'] as Map<String, dynamic>?;
+      if (sender == null || content == null) return;
+      if (sender == client.userID) return;
+
+      final requestedUsers = (content['requested_users'] as List<dynamic>?)?.cast<String>();
+      if (requestedUsers != null && !requestedUsers.contains(client.userID)) {
+        return; // Not for us.
+      }
+
+      if (userRepository == null ||
+          sharingPreferencesRepository == null ||
+          userService == null ||
+          locationManager == null ||
+          roomService == null) {
+        print('[Location Request] Missing deps; cannot auto-respond');
+        return;
+      }
+
+      // Contact gate — drop silently if sender isn't in our contacts list.
+      final user = await userRepository!.getUserById(sender);
+      if (user == null) {
+        print('[Location Request] Sender $sender not in contacts; dropping');
+        return;
+      }
+
+      final prefs = await sharingPreferencesRepository!.getSharingPreferences(sender, 'user');
+      if (prefs == null || prefs.activeSharing != true) {
+        print('[Location Request] Sharing disabled for $sender; dropping');
+        return;
+      }
+      if (!await userService!.isInSharingWindow(sender)) {
+        print('[Location Request] Outside sharing window for $sender; dropping');
+        return;
+      }
+      if (!await _cooldown.shouldRespondToLocationRequest(sender)) {
+        print('[Location Request] Throttled response to $sender');
+        return;
+      }
+
+      print('[Location Request] Responding to $sender in room $roomId');
+      await locationManager!.grabLocationAndPing();
+      await roomService!.updateSingleRoom(roomId);
+      await _cooldown.markLocationResponded(sender);
+    } catch (e) {
+      print('[Location Request] Error handling request: $e');
     }
   }
 

--- a/lib/services/message_processor.dart
+++ b/lib/services/message_processor.dart
@@ -545,25 +545,38 @@ class MessageProcessor {
     try {
       final sender = messageData['sender'] as String?;
       final content = messageData['content'] as Map<String, dynamic>?;
-      
+
       if (sender == null || content == null) {
         print('[Avatar Request] Invalid request - missing sender or content');
         return;
       }
 
       // Don't respond to our own requests
-      if (sender == client.userID) {
+      if (sender == client.userID) return;
+
+      // Contact gate — silently ignore non-contact requesters. (UserRepo
+      // is optional during construction; if absent, fall back to legacy
+      // unconditional behaviour to avoid breaking older wiring paths.)
+      if (userRepository != null) {
+        final user = await userRepository!.getUserById(sender);
+        if (user == null) {
+          print('[Avatar Request] Sender $sender not in contacts; dropping');
+          return;
+        }
+      }
+
+      if (!await _cooldown.shouldRespondToAvatarRequest(sender)) {
+        print('[Avatar Request] Throttled response to $sender');
         return;
       }
 
       final requestedUsers = content['requested_users'] as List<dynamic>?;
-      
+
       print('[Avatar Request] Received avatar request from $sender for users: ${requestedUsers?.join(", ") ?? "all"}');
-      
-      // Use the avatar service to handle the request
+
       final avatarService = AvatarAnnouncementService(client);
       await avatarService.handleAvatarRequest(roomId, sender, requestedUsers?.cast<String>());
-      
+      await _cooldown.markAvatarResponded(sender);
     } catch (e) {
       print('[Avatar Request] Error handling avatar request: $e');
     }

--- a/lib/services/message_processor.dart
+++ b/lib/services/message_processor.dart
@@ -126,6 +126,8 @@ class MessageProcessor {
         await _handleAvatarState(messageData);
       } else if (msgType == 'm.avatar.request') {
         await _handleAvatarRequest(messageData, roomId);
+      } else if (msgType == 'm.avatar.absent') {
+        await _handleAvatarAbsent(messageData);
       } else if (msgType == 'm.location.request') {
         await _handleLocationRequest(messageData, roomId);
       } else if (_isMapIconEvent(msgType)) {
@@ -468,6 +470,19 @@ class MessageProcessor {
       print('[Avatar State] Finished processing ${avatarsList.length} avatars from state bundle');
     } catch (e) {
       print('[Avatar State] Error handling avatar state: $e');
+    }
+  }
+
+  /// Handle peer reply indicating they have no avatar set; record the
+  /// absence so we extend the cooldown before asking again.
+  Future<void> _handleAvatarAbsent(Map<String, dynamic> messageData) async {
+    try {
+      final sender = messageData['sender'] as String?;
+      if (sender == null || sender == client.userID) return;
+      print('[Avatar Absent] Recording absence for $sender');
+      await _cooldown.markAvatarAbsent(sender);
+    } catch (e) {
+      print('[Avatar Absent] Error handling absence: $e');
     }
   }
 

--- a/lib/services/push/notification_display.dart
+++ b/lib/services/push/notification_display.dart
@@ -187,6 +187,8 @@ class NotificationDisplay {
       'm.group.avatar.announcement',
       'm.avatar.state',
       'm.avatar.request',
+      'm.avatar.absent',
+      'm.location.request',
       'm.map.icon.create',
       'm.map.icon.update',
       'm.map.icon.delete',

--- a/lib/services/request_cooldown_service.dart
+++ b/lib/services/request_cooldown_service.dart
@@ -1,0 +1,90 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks per-user cooldowns for opportunistic avatar/location nudge requests.
+///
+/// All timestamps are epoch milliseconds in SharedPreferences. Designed to be
+/// instantiated ad-hoc (cheap; SharedPreferences itself is a singleton under
+/// the hood) so callers don't need DI plumbing.
+class RequestCooldownService {
+  // Outgoing-request cooldowns (we asked someone for X recently, don't re-ask).
+  static const Duration _avatarRequestCooldown = Duration(hours: 24);
+  static const Duration _locationRequestCooldown = Duration(hours: 6);
+  // Longer cooldown when responder explicitly told us they have no avatar set.
+  static const Duration _avatarAbsentCooldown = Duration(days: 7);
+
+  // Incoming-response throttles (we just answered someone, don't re-answer).
+  static const Duration _avatarRespondCooldown = Duration(hours: 1);
+  static const Duration _locationRespondCooldown = Duration(minutes: 30);
+
+  String _avReqKey(String userId) => 'nudge_avreq_$userId';
+  String _locReqKey(String userId) => 'nudge_locreq_$userId';
+  String _avRespKey(String senderId) => 'nudge_avresp_$senderId';
+  String _locRespKey(String senderId) => 'nudge_locresp_$senderId';
+  String _avAbsentKey(String userId) => 'nudge_avabsent_$userId';
+
+  int _now() => DateTime.now().millisecondsSinceEpoch;
+
+  Future<bool> _isPastCooldown(String key, Duration cooldown) async {
+    final prefs = await SharedPreferences.getInstance();
+    final last = prefs.getInt(key);
+    if (last == null) return true;
+    return _now() - last >= cooldown.inMilliseconds;
+  }
+
+  Future<void> _stamp(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(key, _now());
+  }
+
+  /// True if we may request the avatar from [userId] now.
+  Future<bool> shouldRequestAvatar(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final absentAt = prefs.getInt(_avAbsentKey(userId));
+    if (absentAt != null &&
+        _now() - absentAt < _avatarAbsentCooldown.inMilliseconds) {
+      return false;
+    }
+    return _isPastCooldown(_avReqKey(userId), _avatarRequestCooldown);
+  }
+
+  /// True if we may request the location from [userId] now.
+  Future<bool> shouldRequestLocation(String userId) async {
+    return _isPastCooldown(_locReqKey(userId), _locationRequestCooldown);
+  }
+
+  Future<void> markAvatarRequested(String userId) async {
+    await _stamp(_avReqKey(userId));
+  }
+
+  Future<void> markLocationRequested(String userId) async {
+    await _stamp(_locReqKey(userId));
+  }
+
+  /// Record that [userId] told us they have no avatar set. Suppresses
+  /// further avatar requests until the absent cooldown expires.
+  Future<void> markAvatarAbsent(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_avAbsentKey(userId), _now());
+    await prefs.setInt(_avReqKey(userId), _now());
+  }
+
+  /// True if we have not responded to an avatar request from [senderId]
+  /// within the response throttle window.
+  Future<bool> shouldRespondToAvatarRequest(String senderId) async {
+    return _isPastCooldown(_avRespKey(senderId), _avatarRespondCooldown);
+  }
+
+  /// True if we have not responded to a location request from [senderId]
+  /// within the response throttle window.
+  Future<bool> shouldRespondToLocationRequest(String senderId) async {
+    return _isPastCooldown(_locRespKey(senderId), _locationRespondCooldown);
+  }
+
+  Future<void> markAvatarResponded(String senderId) async {
+    await _stamp(_avRespKey(senderId));
+  }
+
+  Future<void> markLocationResponded(String senderId) async {
+    await _stamp(_locRespKey(senderId));
+  }
+}

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -16,6 +16,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:grid_frontend/providers/user_location_provider.dart';
 import 'package:grid_frontend/services/avatar_announcement_service.dart';
 import 'package:grid_frontend/services/map_icon_sync_service.dart';
+import 'package:grid_frontend/services/request_cooldown_service.dart';
 
 import 'package:grid_frontend/repositories/sharing_preferences_repository.dart';
 import 'package:grid_frontend/services/location_manager.dart';
@@ -98,6 +99,12 @@ class SyncManager with ChangeNotifier {
   final List<Function> _postSyncOperations = [];
   DateTime? _lastRoomUpdateTime;
   static const Duration _minRoomUpdateInterval = Duration(seconds: 5);
+
+  // Nudge pass state — see _runNudgePass().
+  final RequestCooldownService _cooldown = RequestCooldownService();
+  DateTime? _pausedTime;
+  bool _firstNudgeScheduled = false;
+  static const Duration _resumeNudgeThreshold = Duration(hours: 6);
 
 
   SyncManager(
@@ -284,6 +291,7 @@ class SyncManager with ChangeNotifier {
       _isInitialized = true;
       _setSyncState(SyncState.ready);
       await _processQueuedOperations();
+      _scheduleFirstStartupNudge();
     } catch (e) {
       print("[SyncManager] Error during initialization: $e");
       _setSyncState(SyncState.error);
@@ -400,6 +408,81 @@ class SyncManager with ChangeNotifier {
       if (client.isLogged() && (!_isSyncing || !client.syncPending)) {
         _startSyncStream();
       }
+
+      // If we were paused long enough, opportunistically nudge contacts for
+      // any missing avatars / stale locations.
+      final pausedAt = _pausedTime;
+      if (pausedAt != null &&
+          DateTime.now().difference(pausedAt) >= _resumeNudgeThreshold) {
+        unawaited(_runNudgePass());
+      }
+      _pausedTime = null;
+    } else {
+      _pausedTime = DateTime.now();
+    }
+  }
+
+  /// Defer the cold-launch nudge pass so it doesn't pile onto the hot path.
+  void _scheduleFirstStartupNudge() {
+    if (_firstNudgeScheduled) return;
+    _firstNudgeScheduled = true;
+    Future.delayed(const Duration(seconds: 5), () {
+      if (_stopped) return;
+      unawaited(_runNudgePass());
+    });
+  }
+
+  /// Walk every joined room and send targeted avatar/location requests for
+  /// members whose per-user cooldown has expired. Spreads work with a short
+  /// per-room sleep to avoid bursts.
+  Future<void> _runNudgePass() async {
+    try {
+      if (_stopped) return;
+      final myId = client.userID;
+      if (myId == null) return;
+      final avatarService = AvatarAnnouncementService(client);
+      final rooms = client.rooms
+          .where((r) => r.membership == Membership.join)
+          .toList();
+      print('[Nudge] Starting nudge pass across ${rooms.length} rooms');
+
+      for (final room in rooms) {
+        if (_stopped) return;
+        try {
+          final participants = await room.getParticipants();
+          final avatarTargets = <String>[];
+          final locationTargets = <String>[];
+          for (final p in participants) {
+            if (p.id == myId) continue;
+            if (p.membership != Membership.join) continue;
+            if (await _cooldown.shouldRequestAvatar(p.id)) {
+              avatarTargets.add(p.id);
+            }
+            if (await _cooldown.shouldRequestLocation(p.id)) {
+              locationTargets.add(p.id);
+            }
+          }
+
+          if (avatarTargets.isNotEmpty) {
+            await avatarService.requestAvatars(room.id, userIds: avatarTargets);
+            for (final uid in avatarTargets) {
+              await _cooldown.markAvatarRequested(uid);
+            }
+          }
+          if (locationTargets.isNotEmpty) {
+            await avatarService.requestLocations(room.id, userIds: locationTargets);
+            for (final uid in locationTargets) {
+              await _cooldown.markLocationRequested(uid);
+            }
+          }
+        } catch (e) {
+          print('[Nudge] Error in room ${room.id}: $e');
+        }
+        await Future.delayed(const Duration(milliseconds: 200));
+      }
+      print('[Nudge] Pass complete');
+    } catch (e) {
+      print('[Nudge] Pass failed: $e');
     }
   }
 
@@ -1036,7 +1119,7 @@ class SyncManager with ChangeNotifier {
                 // For direct rooms, check sharing preferences
                 final sharingPrefs = await sharingPreferencesRepository.getSharingPreferences(event.stateKey!, 'user');
                 final isSharingEnabled = sharingPrefs?.activeSharing ?? true; // Default to true if no prefs
-                
+
                 if (isSharingEnabled) {
                   print("New member joined direct room, sending initial location");
                   // Grab fresh location and send it
@@ -1049,6 +1132,17 @@ class SyncManager with ChangeNotifier {
                   }
                 } else {
                   print("Location sharing disabled for ${event.stateKey}, not sending initial location");
+                }
+
+                // Also ask the new contact for their location so they appear
+                // on the map without waiting for their next periodic ping.
+                if (await _cooldown.shouldRequestLocation(event.stateKey!)) {
+                  try {
+                    await avatarService.requestLocations(roomId, userIds: [event.stateKey!]);
+                    await _cooldown.markLocationRequested(event.stateKey!);
+                  } catch (e) {
+                    print('Error requesting location from new contact: $e');
+                  }
                 }
               } else {
                 // For group rooms, always send location when someone joins


### PR DESCRIPTION
## Summary
- The previous narrowed `_foregrounded` guard (`!= paused && != hidden`) was wrong. Cold-launch `AppLifecycleState.inactive` has an MLNMapView whose CALayer is not yet laid out, and MapLibre bounds-clamp produces NaN against the zero-size layer — same SIGABRT as the build 811 class. Testers on build 744 (which shipped this narrowed guard) saw the same `LatLng` ctor crash. Reverting to the strict `== resumed` check.
- Trade-off: on cold launch the first auto-recenter is dropped, so the user dot may not appear until the next location update (then center-on-me works). Recoverable. A crash on first launch is not.
- Bumping the release build-number offset by 75 (709 → 784) so the next release lands at 820, well above the 744 already in TestFlight. App Store Connect requires monotonically increasing CFBundleVersion.

## Changelog
- [x] `fix`
- [ ] `feature`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Fix cold-launch crash that hit TestFlight build 744. Map may not auto-center on first open; tap the locate button to recenter.

## Test plan
- [x] Local sim: no crash on cold launch
- [ ] TestFlight 820: crash reports from the 744 cohort should stop