### PR TITLE
fix(map): gate camera moves on map size + cameraPosition readiness

### DIFF
--- a/changes/pr-266.md
+++ b/changes/pr-266.md
@@ -1,0 +1,1 @@
+[fix] Fix rare map crash when reopening the app from background.

--- a/lib/screens/map/maplibre_camera_facade.dart
+++ b/lib/screens/map/maplibre_camera_facade.dart
@@ -48,7 +48,7 @@ class MaplibreCameraFacade {
 
   /// Snap to a position (no animation). Mirrors `MapController.move`.
   void move(LatLng center, double zoom) {
-    if (!_foregrounded) return;
+    if (!_safeToMove) return;
     if (!isFiniteLatLng(center.latitude, center.longitude)) {
       debugPrint('[Camera] Skipping move — invalid coords: ${center.latitude},${center.longitude}');
       return;
@@ -65,7 +65,7 @@ class MaplibreCameraFacade {
   /// Animate to a position + rotation. Mirrors `MapController.moveAndRotate`.
   /// `rotation` is in degrees; flutter_map called this with 0 to clear bearing.
   void moveAndRotate(LatLng center, double zoom, double rotation) {
-    if (!_foregrounded) return;
+    if (!_safeToMove) return;
     if (!isFiniteLatLng(center.latitude, center.longitude)) {
       debugPrint('[Camera] Skipping moveAndRotate — invalid coords: ${center.latitude},${center.longitude}');
       return;
@@ -81,13 +81,28 @@ class MaplibreCameraFacade {
     ));
   }
 
-  // Only allow moves when fully resumed. The transient `inactive` / `detached`
-  // states on cold-launch and resume have a not-yet-laid-out MLNMapView; running
-  // the bounds-clamp against a zero-size layer NaNs out and throws an uncaught
-  // C++ exception in the native LatLng ctor (SIGABRT). A dropped move is ugly
-  // (no dot until the next location update) but recoverable; a crash is not.
-  bool get _foregrounded =>
-      WidgetsBinding.instance.lifecycleState == AppLifecycleState.resumed;
+  // Native MLNMapView's bounds-clamp throws an uncaught C++ exception (SIGABRT
+  // through __cxa_throw, terminates the process) whenever it's driven before
+  // the underlying CALayer has a real size. We've seen this in two distinct
+  // shapes:
+  //   1. Cold launch: lifecycleState is `inactive`/`detached` while the first
+  //      auto-recenter fires.
+  //   2. Resume from background: lifecycleState flips to `resumed` immediately,
+  //      but the Flutter platform-view hasn't been re-laid-out yet — _mapSize
+  //      is still Size.zero, and the native cameraPosition reads as null.
+  // Strict resumed + non-zero map size + readable cameraPosition together
+  // cover both: any one of them being unhappy means the native view isn't safe
+  // to drive. A dropped move is ugly (no dot until the next update); a crash
+  // takes the whole app down.
+  bool get _safeToMove {
+    if (_ml == null) return false;
+    if (WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
+      return false;
+    }
+    if (_mapSize == Size.zero) return false;
+    if (_ml?.cameraPosition == null) return false;
+    return true;
+  }
 
   double _safeZoom(double zoom) {
     if (zoom.isNaN || zoom.isInfinite) return 2.0;

--- a/lib/screens/settings/home_location_picker_screen.dart
+++ b/lib/screens/settings/home_location_picker_screen.dart
@@ -106,6 +106,14 @@ class _HomeLocationPickerScreenState extends State<HomeLocationPickerScreen>
     if (!mounted || _isInteracting) return;
     final controller = _mlController;
     if (controller == null) return;
+    // Same crash-shape as MaplibreCameraFacade: native MLNMapView throws an
+    // uncaught C++ exception out of constrainCameraAndZoomToBounds whenever
+    // its layer isn't laid out yet. Skip the move if we're not in a clean
+    // foregrounded + ready-controller state.
+    if (WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
+      return;
+    }
+    if (controller.cameraPosition == null) return;
     controller.animateCamera(ml.CameraUpdate.newCameraPosition(
       ml.CameraPosition(
         target: ml.LatLng(target.latitude, target.longitude),

--- a/lib/widgets/location_history_modal.dart
+++ b/lib/widgets/location_history_modal.dart
@@ -427,8 +427,17 @@ class _LocationHistoryModalState extends State<LocationHistoryModal> {
       debugPrint('[History] Skipping moveCamera — invalid coords: ${target.latitude},${target.longitude}');
       return;
     }
+    final controller = _mapController;
+    if (controller == null) return;
+    // Native MLNMapView throws an uncaught C++ exception out of
+    // constrainCameraAndZoomToBounds whenever its layer isn't laid out yet
+    // (e.g. modal opening, resume from background). Skip the move in that case.
+    if (WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
+      return;
+    }
+    if (controller.cameraPosition == null) return;
     final z = (zoom.isNaN || zoom.isInfinite) ? 2.0 : zoom.clamp(0.0, 22.0);
-    _mapController?.moveCamera(ml.CameraUpdate.newCameraPosition(
+    controller.moveCamera(ml.CameraUpdate.newCameraPosition(
       ml.CameraPosition(
         target: ml.LatLng(target.latitude, target.longitude),
         zoom: z,


### PR DESCRIPTION
## Summary
- Resume-from-background still crashes on 820 with the same MapLibre SIGABRT
- Strict lifecycle==resumed flips true the instant iOS hands the app back, but the MLNMapView layer has not been re-laid-out yet, so constrainCameraAndZoomToBounds NaNs out and throws an uncaught C++ exception
- Strengthens the facade gate to require all four signals: controller attached, lifecycle resumed, _mapSize non-zero, and controller.cameraPosition non-null
- Mirrors the same gate at the two call sites that bypass the facade (home_location_picker_screen, location_history_modal)

## Changelog
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Fix rare map crash when reopening the app from background.

## Test plan
- [x] Static analysis clean on the three changed files
- [ ] TestFlight install on physical device, background ~5 min, foreground, repeat — no crash