### PR TITLE
feat: speed unit preference (mph / km/h)

### DIFF
--- a/changes/pr-268.md
+++ b/changes/pr-268.md
@@ -1,0 +1,1 @@
+[improvement] Add mph / km/h speed unit toggle in Settings → Display.

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -83,6 +83,7 @@ class _SettingsPageState extends State<SettingsPage> {
   SharingMode _sharingMode = SharingMode.balanced;
   bool _autoPauseAtHome = false;
   bool _homeLocationSet = false;
+  String _speedUnit = 'mph';
   String? _userID;
   String? _username;
   String? _localpart;
@@ -129,6 +130,7 @@ class _SettingsPageState extends State<SettingsPage> {
     _loadIncognitoState();
     _loadBatterySaverState();
     _loadAutoPauseAtHomeState();
+    _loadSpeedUnit();
     _loadCachedAvatar();
     _loadAppVersion();
   }
@@ -192,6 +194,19 @@ class _SettingsPageState extends State<SettingsPage> {
           prefs.getBool('auto_pause_at_home_enabled') ?? false;
       _homeLocationSet = saved != null && saved.trim().isNotEmpty;
     });
+  }
+
+  Future<void> _loadSpeedUnit() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _speedUnit = prefs.getString('speed_unit') ?? 'mph';
+    });
+  }
+
+  Future<void> _setSpeedUnit(String unit) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('speed_unit', unit);
+    setState(() => _speedUnit = unit);
   }
 
   void _showExpandedAvatar(BuildContext context) {
@@ -2495,6 +2510,16 @@ class _SettingsPageState extends State<SettingsPage> {
               ],
             ),
 
+            // ── Display ─────────────────────────────────────
+            const GridSectionHeader(text: 'Display'),
+            _buildSectionCard(
+              theme: theme,
+              colorScheme: colorScheme,
+              children: [
+                _buildSpeedUnitRow(colorScheme),
+              ],
+            ),
+
             // ── Privacy & security ──────────────────────────
             const GridSectionHeader(text: 'Privacy & security'),
             _buildSectionCard(
@@ -3043,6 +3068,38 @@ class _SettingsPageState extends State<SettingsPage> {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildSpeedUnitRow(ColorScheme colorScheme) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Icon(Icons.speed_outlined, size: 20, color: context.gridColors.text2),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              'Speed unit',
+              style: GoogleFonts.getFont(
+                'Geist',
+                color: context.gridColors.text,
+                fontSize: 15,
+                fontWeight: FontWeight.w500,
+                letterSpacing: -0.01,
+              ),
+            ),
+          ),
+          GridSegmented(
+            tabs: const [
+              GridSegmentedTab(label: 'mph'),
+              GridSegmentedTab(label: 'km/h'),
+            ],
+            selected: _speedUnit == 'kmh' ? 1 : 0,
+            onChanged: (i) => _setSpeedUnit(i == 0 ? 'mph' : 'kmh'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/widgets/contact_profile_modal.dart
+++ b/lib/widgets/contact_profile_modal.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
+import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -83,6 +85,7 @@ class _ContactProfileModalState extends State<ContactProfileModal> {
   bool _copied = false;
   bool _isLoading = true;
   bool _activeSharing = false;
+  String _speedUnit = 'mph';
 
   /// All device keys (fetched from the RoomService)
   late Map<String, Map<String, String>> _allOtherDeviceKeys;
@@ -106,6 +109,15 @@ class _ContactProfileModalState extends State<ContactProfileModal> {
     _loadDeviceKeys();
     _computeRelationship();
     _subscribeToContacts();
+    _loadSpeedUnit();
+  }
+
+  Future<void> _loadSpeedUnit() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!mounted) return;
+    setState(() {
+      _speedUnit = prefs.getString('speed_unit') ?? 'mph';
+    });
   }
 
   @override
@@ -855,6 +867,9 @@ class _ContactProfileModalState extends State<ContactProfileModal> {
 
   String? _formatSpeed(double? speedMps) {
     if (speedMps == null || speedMps < 1.4) return null;
+    if (_speedUnit == 'kmh') {
+      return '${(speedMps * 3.6).round()} km/h';
+    }
     return '${(speedMps * 2.236936).round()} mph';
   }
 

--- a/lib/widgets/user_info_bubble.dart
+++ b/lib/widgets/user_info_bubble.dart
@@ -4,6 +4,7 @@ import 'dart:ui' show ImageFilter;
 import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:latlong2/latlong.dart';
@@ -25,7 +26,7 @@ import 'package:grid_frontend/widgets/user_avatar_bloc.dart';
 ///
 /// Positioning is owned by the parent (MapTab); this widget keeps the
 /// existing `Positioned` envelope so the call-site doesn't change.
-class UserInfoBubble extends StatelessWidget {
+class UserInfoBubble extends StatefulWidget {
   final String userId;
   final String userName;
   final LatLng position;
@@ -40,6 +41,27 @@ class UserInfoBubble extends StatelessWidget {
     this.lastUpdate,
     this.onClose,
   });
+
+  @override
+  State<UserInfoBubble> createState() => _UserInfoBubbleState();
+}
+
+class _UserInfoBubbleState extends State<UserInfoBubble> {
+  String _speedUnit = 'mph';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSpeedUnit();
+  }
+
+  Future<void> _loadSpeedUnit() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!mounted) return;
+    setState(() {
+      _speedUnit = prefs.getString('speed_unit') ?? 'mph';
+    });
+  }
 
   /// `null` when we don't know the user's own location yet (so the cell is
   /// hidden rather than showing a fake number).
@@ -351,12 +373,14 @@ class UserInfoBubble extends StatelessWidget {
     return 'DRIVING';
   }
 
-  /// Speed as "12 mph". Null when no useful motion or speed isn't
-  /// known.
+  /// Speed as "12 mph" or "19 km/h". Null when no useful motion or speed
+  /// isn't known.
   String? _formatSpeed(double? speedMps) {
     if (speedMps == null || speedMps < 1.4) return null;
-    final mph = speedMps * 2.236936;
-    return '${mph.round()} mph';
+    if (_speedUnit == 'kmh') {
+      return '${(speedMps * 3.6).round()} km/h';
+    }
+    return '${(speedMps * 2.236936).round()} mph';
   }
 
   String _formatCoordinates(LatLng p) {
@@ -379,17 +403,17 @@ class UserInfoBubble extends StatelessWidget {
     final topOffset = media.padding.top + 96;
     final myLocation =
         Provider.of<LocationManager>(context, listen: false).currentLatLng;
-    final distanceLabel = _formatDistance(myLocation, position);
-    final bearingLabel = _formatBearing(myLocation, position);
-    final updatedLabel = lastUpdate == null
+    final distanceLabel = _formatDistance(myLocation, widget.position);
+    final bearingLabel = _formatBearing(myLocation, widget.position);
+    final updatedLabel = widget.lastUpdate == null
         ? null
-        : TimeAgoFormatter.format(lastUpdate);
+        : TimeAgoFormatter.format(widget.lastUpdate);
 
     // gridv 2: opportunistic speed + battery from the sender's last
     // m.location. context.watch so the bubble rebuilds as new fixes
     // arrive while it's open.
     final status =
-        context.watch<UserDeviceStatusCache>().statusFor(userId);
+        context.watch<UserDeviceStatusCache>().statusFor(widget.userId);
     final motionLabel = _formatMotion(status?.speed);
     final speedLabel = _formatSpeed(status?.speed);
 
@@ -430,12 +454,12 @@ class UserInfoBubble extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         _IdentityRow(
-                          userId: userId,
-                          userName: userName,
-                          coordinatesLabel: _formatCoordinates(position),
+                          userId: widget.userId,
+                          userName: widget.userName,
+                          coordinatesLabel: _formatCoordinates(widget.position),
                           onCopyCoordinates: () =>
-                              _copyCoordinates(context, position),
-                          onClose: onClose,
+                              _copyCoordinates(context, widget.position),
+                          onClose: widget.onClose,
                           batteryLevel: status?.batteryLevel,
                           isCharging: status?.isCharging,
                         ),
@@ -463,7 +487,7 @@ class UserInfoBubble extends StatelessWidget {
                               child: _MiniBtn(
                                 icon: Icons.near_me_rounded,
                                 label: 'Route',
-                                onTap: () => _openInMaps(context, position),
+                                onTap: () => _openInMaps(context, widget.position),
                               ),
                             ),
                           ],


### PR DESCRIPTION
Addresses Rezivure/Grid-Mobile#267

## What changed

- Added `speed_unit` SharedPreferences key (`"mph"` or `"kmh"`, default `"mph"`)
- Added a **Speed unit** segmented toggle (mph / km/h) under Settings → Display in `settings_page.dart`
- Updated `_formatSpeed` in `contact_profile_modal.dart` to read the preference and render km/h when selected
- Updated `_formatSpeed` in `user_info_bubble.dart` to read the preference; converted `UserInfoBubble` from `StatelessWidget` to `StatefulWidget` to support async preference loading

## Why

Users outside the US (and Life360 switchers) expect to see speed in km/h. The speed value already flowed through the data pipeline end-to-end; the only thing missing was a per-user unit preference and the corresponding display logic.

## Risk

Low. All changes are display-only; no data model or network layer is touched. Existing users default to mph, so no visible behaviour change until they opt in. The StatefulWidget conversion of `UserInfoBubble` is mechanical and does not alter its public API.

## Changelog
- [ ] `feature`
- [ ] `fix`
- [x] `improvement`
- [ ] `skip`

**Release note:**
Add mph / km/h speed unit toggle in Settings → Display.

## Test plan
- [x] Static analysis passes on the three changed files
- [ ] Toggle to km/h in Settings → Display; open a contact profile while they are moving — speed pill shows km/h
- [ ] Toggle to mph; same contact — pill reverts to mph
- [ ] Tap a contact pin on the map; user info bubble shows the selected unit
- [ ] Preference survives app restart

_Agent-generated by the daily-issue-pipeline routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_018haesdckjRCrNEr3dEUdsR)_