### PR TITLE
fix(map): gate camera moves on first onCameraIdle (native render proof)

### DIFF
--- a/changes/pr-270.md
+++ b/changes/pr-270.md
@@ -1,0 +1,1 @@
+[fix] Fix recurring map crash on resume and when opening location history.

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -859,39 +859,12 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
     // Normal resume handling for short pauses
     _syncManager?.handleAppLifecycleState(state == AppLifecycleState.resumed);
     
-    // Only reinitialize if app was paused for a significant time
-    if (state == AppLifecycleState.resumed && _pausedTime != null) {
-      final pauseDuration = DateTime.now().difference(_pausedTime!);
-
-      if (pauseDuration.inSeconds > 5) {
-        print('[MapTab] App resumed after ${pauseDuration.inSeconds}s - rebuilding map');
-
-        // Single rebuild after short delay
-        Future.delayed(const Duration(milliseconds: 400), () async {
-          if (mounted && _isMapReady) {
-            // Store current position
-            final currentCenter = _mapController.camera.center;
-            final currentZoom = _mapController.camera.zoom;
-
-            // Reload the tile provider
-            await _loadMapProvider();
-
-            // Single map rebuild
-            setState(() {
-              _mapKey = UniqueKey();
-              print('[MapTab] Map rebuilt after resume');
-            });
-
-            // Restore position after rebuild
-            Future.delayed(const Duration(milliseconds: 200), () {
-              if (mounted && _isMapReady && currentCenter != null) {
-                _mapController.move(currentCenter, currentZoom);
-              }
-            });
-          }
-        });
-      }
-    }
+    // We used to force a full MLNMapView rebuild (`_mapKey = UniqueKey()`)
+    // on resume, but recreating the platform view re-enters the native
+    // zero-frame race that throws std::domain_error out of LatLng. The
+    // existing MLNMapView survives backgrounding fine; if dark-mode flipped
+    // while we were away, the style swap is already handled elsewhere via
+    // `setStyle` on the existing controller. So: do nothing here.
   }
 
   void _backwardsCompatibilityUpdate() async {

--- a/lib/screens/map/maplibre_camera_facade.dart
+++ b/lib/screens/map/maplibre_camera_facade.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -18,17 +19,36 @@ class MaplibreCameraFacade {
   CameraSnapshot _snapshot = const CameraSnapshot._empty();
   Size _mapSize = Size.zero;
 
+  // "Native view has rendered at least one frame" gate. Set to true on the
+  // first onCameraIdle callback after attach. Until then, camera moves are
+  // buffered into `_pending` (single-slot — latest wins) and replayed once
+  // the gate opens. See `_safeToMove` for the full story.
+  bool _nativeViewReady = false;
+  _PendingMove? _pending;
+  Timer? _safetyTimer;
+
   void attach(ml.MapLibreMapController controller) {
     _ml = controller;
+    _nativeViewReady = false;
+    _pending = null;
+    _safetyTimer?.cancel();
+    // Safety net: if onCameraIdle never fires (shouldn't happen, but if the
+    // map somehow gets wedged we'd rather drop the gate than freeze the UI).
+    _safetyTimer = Timer(const Duration(seconds: 5), _openGate);
     syncFromController();
   }
 
   void detach() {
     _ml = null;
+    _nativeViewReady = false;
+    _pending = null;
+    _safetyTimer?.cancel();
+    _safetyTimer = null;
   }
 
   /// Updates the camera snapshot from the live controller. Call this on
-  /// `onCameraIdle` (and at attach).
+  /// `onCameraIdle` (and at attach). Also opens the native-ready gate on
+  /// the first idle that yields a valid camera.
   void syncFromController() {
     final pos = _ml?.cameraPosition;
     if (pos == null) return;
@@ -39,6 +59,30 @@ class MaplibreCameraFacade {
       bearing: pos.bearing,
       mapSize: _mapSize,
     );
+    if (!_nativeViewReady) _openGate();
+  }
+
+  void _openGate() {
+    if (_nativeViewReady) return;
+    _nativeViewReady = true;
+    _safetyTimer?.cancel();
+    _safetyTimer = null;
+    final pending = _pending;
+    _pending = null;
+    if (pending != null) {
+      // Defer to a microtask so we're not re-entering during the very
+      // callback that opened the gate.
+      scheduleMicrotask(() => _applyPending(pending));
+    }
+  }
+
+  void _applyPending(_PendingMove p) {
+    if (_ml == null) return;
+    if (p.animated) {
+      moveAndRotate(p.center, p.zoom, p.rotation);
+    } else {
+      move(p.center, p.zoom);
+    }
   }
 
   void setMapSize(Size size) {
@@ -48,9 +92,12 @@ class MaplibreCameraFacade {
 
   /// Snap to a position (no animation). Mirrors `MapController.move`.
   void move(LatLng center, double zoom) {
-    if (!_safeToMove) return;
     if (!isFiniteLatLng(center.latitude, center.longitude)) {
       debugPrint('[Camera] Skipping move — invalid coords: ${center.latitude},${center.longitude}');
+      return;
+    }
+    if (!_safeToMove) {
+      _pending = _PendingMove(center, zoom, 0.0, animated: false);
       return;
     }
     final z = _safeZoom(zoom);
@@ -65,13 +112,16 @@ class MaplibreCameraFacade {
   /// Animate to a position + rotation. Mirrors `MapController.moveAndRotate`.
   /// `rotation` is in degrees; flutter_map called this with 0 to clear bearing.
   void moveAndRotate(LatLng center, double zoom, double rotation) {
-    if (!_safeToMove) return;
     if (!isFiniteLatLng(center.latitude, center.longitude)) {
       debugPrint('[Camera] Skipping moveAndRotate — invalid coords: ${center.latitude},${center.longitude}');
       return;
     }
-    final z = _safeZoom(zoom);
     final r = (rotation.isNaN || rotation.isInfinite) ? 0.0 : rotation;
+    if (!_safeToMove) {
+      _pending = _PendingMove(center, zoom, r, animated: true);
+      return;
+    }
+    final z = _safeZoom(zoom);
     _ml?.animateCamera(ml.CameraUpdate.newCameraPosition(
       ml.CameraPosition(
         target: ml.LatLng(center.latitude, center.longitude),
@@ -81,27 +131,24 @@ class MaplibreCameraFacade {
     ));
   }
 
-  // Native MLNMapView's bounds-clamp throws an uncaught C++ exception (SIGABRT
-  // through __cxa_throw, terminates the process) whenever it's driven before
-  // the underlying CALayer has a real size. We've seen this in two distinct
-  // shapes:
-  //   1. Cold launch: lifecycleState is `inactive`/`detached` while the first
-  //      auto-recenter fires.
-  //   2. Resume from background: lifecycleState flips to `resumed` immediately,
-  //      but the Flutter platform-view hasn't been re-laid-out yet — _mapSize
-  //      is still Size.zero, and the native cameraPosition reads as null.
-  // Strict resumed + non-zero map size + readable cameraPosition together
-  // cover both: any one of them being unhappy means the native view isn't safe
-  // to drive. A dropped move is ugly (no dot until the next update); a crash
-  // takes the whole app down.
+  // The native MLNMapView's bounds-clamp throws an uncaught C++ exception
+  // (`std::domain_error` from `mbgl::LatLng`, → SIGABRT) whenever it runs
+  // while `mapView.frame.size == .zero` — the zero-size viewport NaN's out
+  // through `constrainCameraAndZoomToBounds`. Upstream issue #819 / PR #820
+  // confirm; PR was never merged.
+  //
+  // No Dart-side observable reliably mirrors the native frame: Flutter's
+  // `LayoutBuilder` size and `controller.cameraPosition` can both report
+  // "ready" while the embedded UIView's layer is still zero. The only signal
+  // that genuinely implies "native renderer has produced a frame" is the
+  // first `onCameraIdle` after attach — that's what `_nativeViewReady` waits
+  // for. Lifecycle/finite checks remain as cheap sanity guards.
   bool get _safeToMove {
     if (_ml == null) return false;
     if (WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
       return false;
     }
-    if (_mapSize == Size.zero) return false;
-    if (_ml?.cameraPosition == null) return false;
-    return true;
+    return _nativeViewReady;
   }
 
   double _safeZoom(double zoom) {
@@ -115,6 +162,14 @@ class MaplibreCameraFacade {
   void dispose() {
     detach();
   }
+}
+
+class _PendingMove {
+  _PendingMove(this.center, this.zoom, this.rotation, {required this.animated});
+  final LatLng center;
+  final double zoom;
+  final double rotation;
+  final bool animated;
 }
 
 /// Read-only camera state — what the old code accessed via

--- a/lib/screens/settings/home_location_picker_screen.dart
+++ b/lib/screens/settings/home_location_picker_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -49,6 +50,12 @@ class _HomeLocationPickerScreenState extends State<HomeLocationPickerScreen>
   bool _confirming = false;
   bool? _isDarkStyle;
   String? _styleJson;
+  // Native MLNMapView's bounds-clamp NaN's out when frame.size == .zero,
+  // which is the case during the picker screen's push transition. Wait for
+  // the first onCameraIdle to confirm the view has rendered before issuing
+  // any animateCamera. See maplibre_camera_facade.dart for the full story.
+  bool _nativeReady = false;
+  ll.LatLng? _pendingTarget;
 
   late double _radiusMeters = widget.initialRadiusMeters.clamp(_minRadius, _maxRadius);
 
@@ -106,20 +113,31 @@ class _HomeLocationPickerScreenState extends State<HomeLocationPickerScreen>
     if (!mounted || _isInteracting) return;
     final controller = _mlController;
     if (controller == null) return;
-    // Same crash-shape as MaplibreCameraFacade: native MLNMapView throws an
-    // uncaught C++ exception out of constrainCameraAndZoomToBounds whenever
-    // its layer isn't laid out yet. Skip the move if we're not in a clean
-    // foregrounded + ready-controller state.
     if (WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
       return;
     }
-    if (controller.cameraPosition == null) return;
+    if (!_nativeReady) {
+      _pendingTarget = target;
+      return;
+    }
     controller.animateCamera(ml.CameraUpdate.newCameraPosition(
       ml.CameraPosition(
         target: ml.LatLng(target.latitude, target.longitude),
         zoom: 16,
       ),
     ));
+  }
+
+  void _onNativeReady() {
+    if (_nativeReady) return;
+    _nativeReady = true;
+    final pending = _pendingTarget;
+    _pendingTarget = null;
+    if (pending != null) {
+      scheduleMicrotask(() {
+        if (mounted) _moveCameraTo(pending);
+      });
+    }
   }
 
   @override
@@ -240,6 +258,7 @@ class _HomeLocationPickerScreenState extends State<HomeLocationPickerScreen>
               },
               onCameraTrackingDismissed: () {},
               onCameraIdle: () {
+                _onNativeReady();
                 if (_isInteracting && mounted) {
                   setState(() => _isInteracting = false);
                 }

--- a/lib/widgets/location_history_modal.dart
+++ b/lib/widgets/location_history_modal.dart
@@ -61,6 +61,13 @@ class _LocationHistoryModalState extends State<LocationHistoryModal> {
   String? _selectedMemberId; // For group view, which member is selected
   bool _showAllMembers = false; // Toggle for showing all members vs single
   bool _mapReady = false;
+  // First onCameraIdle after the platform view attaches. Until this fires the
+  // native MLNMapView's frame may still be zero (the modal sheet animates up
+  // from 0 height), and any setCamera call NaNs out through
+  // constrainCameraAndZoomToBounds → SIGABRT. See maplibre_camera_facade.dart
+  // for the full backstory.
+  bool _nativeReady = false;
+  _PendingHistoryMove? _pendingMove;
   Map<String, String> _userDisplayNames = {}; // Cache for display names
   late RoomLocationHistoryRepository _roomHistoryRepo;
   int _playbackSpeed = 1; // 1x / 2x / 4x — UI chrome to match design spec
@@ -429,20 +436,32 @@ class _LocationHistoryModalState extends State<LocationHistoryModal> {
     }
     final controller = _mapController;
     if (controller == null) return;
-    // Native MLNMapView throws an uncaught C++ exception out of
-    // constrainCameraAndZoomToBounds whenever its layer isn't laid out yet
-    // (e.g. modal opening, resume from background). Skip the move in that case.
     if (WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
       return;
     }
-    if (controller.cameraPosition == null) return;
     final z = (zoom.isNaN || zoom.isInfinite) ? 2.0 : zoom.clamp(0.0, 22.0);
+    if (!_nativeReady) {
+      _pendingMove = _PendingHistoryMove(target, z);
+      return;
+    }
     controller.moveCamera(ml.CameraUpdate.newCameraPosition(
       ml.CameraPosition(
         target: ml.LatLng(target.latitude, target.longitude),
         zoom: z,
       ),
     ));
+  }
+
+  void _onNativeReady() {
+    if (_nativeReady) return;
+    _nativeReady = true;
+    final pending = _pendingMove;
+    _pendingMove = null;
+    if (pending != null) {
+      scheduleMicrotask(() {
+        if (mounted) _moveCamera(pending.target, pending.zoom);
+      });
+    }
   }
 
   LatLng? _getPositionAtTime(LocationHistory history, DateTime time) {
@@ -989,6 +1008,7 @@ class _LocationHistoryModalState extends State<LocationHistoryModal> {
                             _refreshMarkerScreenPositions();
                           },
                           onCameraIdle: () {
+                            _onNativeReady();
                             _refreshMarkerScreenPositions();
                           },
                         ),
@@ -1519,4 +1539,9 @@ class _ScrubberTimeLabel extends StatelessWidget {
       ],
     );
   }
+}
+class _PendingHistoryMove {
+  _PendingHistoryMove(this.target, this.zoom);
+  final LatLng target;
+  final double zoom;
 }


### PR DESCRIPTION
## Summary
- Real root cause confirmed via upstream issue #819 and the agent investigation: maplibre-native's `constrainCameraAndZoomToBounds` NaNs out and throws `std::domain_error` from `mbgl::LatLng` whenever `mapView.frame.size == .zero`. The throw is C++, uncatchable from Swift, → SIGABRT.
- No Dart-side observable reliably reflects the native frame. The only signal that genuinely implies the native renderer has produced a frame is the first `onCameraIdle` after attach.
- This PR gates every programmatic camera move on that signal. The latest desired camera is buffered in a single-slot pending move and replays once the gate opens. A 5s safety timer backstops a wedged map so the gate never freezes the UI.
- Also drops `_mapKey = UniqueKey()` resume rebuild in `map_tab.dart` — forced platform-view recreation re-enters the same zero-frame race on every background to foreground transition.
- Same gate applied at the two direct callers that bypass the facade (`location_history_modal`, `home_location_picker_screen`) where the modal sheet animates `frame.size` from 0 over ~250ms.

## Changelog
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Fix recurring map crash on resume and when opening location history.

## Test plan
- [x] Static analysis clean on the four changed files
- [ ] TestFlight: cold launch, modal open, resume from 30s background, resume from 30min background — no SIGABRT