### PR TITLE
fix(map): use Grid fork of maplibre_gl with zero-frame setCamera guard

### DIFF
--- a/changes/pr-271.md
+++ b/changes/pr-271.md
@@ -1,0 +1,1 @@
+[fix] Fix recurring map crash via native zero-frame guard in forked map plugin.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1130,27 +1130,28 @@ packages:
   maplibre_gl:
     dependency: "direct main"
     description:
-      name: maplibre_gl
-      sha256: c97f32353b7c4d15e77c167cc444424556c0be7746dc73fd3deac5f32f858ed4
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.26.0"
+      path: maplibre_gl
+      ref: "fix/grid-defer-camera-on-zero-frame"
+      resolved-ref: "705ca06b77c6938d90d25e2fee640645cc796596"
+      url: "https://github.com/Rezivure/flutter-maplibre-gl.git"
+    source: git
+    version: "0.26.1"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "60ee6ab5671de09dcf7fcb512aedb940024ed03dfcca04a4487dfdd76c906391"
+      sha256: "4989f157fdb98ad346b31067cd30aefa7e67d0b235599e37b75608c9284cb459"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.0"
+    version: "0.26.1"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "63988f302809a46667a40d8ae97882c13a2e0aa1f86808ba47a5e6f311471b59"
+      sha256: "55a03e586d2007b646f163902388c3c17df536ea44e4b1c381754863201862e6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.0"
+    version: "0.26.1"
   markdown:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,6 +99,15 @@ dev_dependencies:
 dependency_overrides:
   flutter_rust_bridge:
     path: patches/flutter_rust_bridge
+  # Fork of maplibre_gl v0.26.1 with upstream PR #820 backported + the
+  # zero-frame guard extended to camera#move and camera#animate handlers.
+  # Fixes the SIGABRT out of mbgl::LatLng that no Dart-side gating could
+  # reliably catch (no Dart observable mirrors MLNMapView.bounds.size).
+  maplibre_gl:
+    git:
+      url: https://github.com/Rezivure/flutter-maplibre-gl.git
+      ref: fix/grid-defer-camera-on-zero-frame
+      path: maplibre_gl
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- Three prior Dart-side gate iterations (builds 820, 821, 823) all failed because no Dart-observable reliably mirrors `MLNMapView.bounds.size`. The native frame is set by UIKit on a separate layout pass from Flutter's widget tree.
- This PR replaces pub.dev maplibre_gl 0.26.1 with a Rezivure fork that backports upstream PR #820 (defer init options-apply when frame is zero) AND extends the same `mapView.bounds.size != .zero` guard to the `camera#move` and `camera#animate` method handlers — the actual crash site in every TestFlight report (`MapLibreMapController.swift:538`).
- Fork: https://github.com/Rezivure/flutter-maplibre-gl branch `fix/grid-defer-camera-on-zero-frame` commit 705ca06.

## Changelog
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Fix recurring map crash via native zero-frame guard in forked map plugin.

## Test plan
- [x] `flutter pub get` resolves the fork cleanly; pubspec.lock pins commit 705ca06
- [x] No new analyzer errors
- [ ] TestFlight cold launch + background resume + history modal open — no SIGABRT