### PR TITLE
fix(keychain): use first_unlock_this_device accessibility + cache key

### DIFF
--- a/changes/pr-274.md
+++ b/changes/pr-274.md
@@ -1,0 +1,1 @@
+[fix] Fix long background resume getting stuck loading after a location wake.

--- a/lib/blocs/avatar/avatar_bloc.dart
+++ b/lib/blocs/avatar/avatar_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:matrix/matrix.dart';
 import 'package:encrypt/encrypt.dart' as encrypt;
@@ -14,7 +15,7 @@ import '../../widgets/group_avatar.dart';
 class AvatarBloc extends Bloc<AvatarEvent, AvatarState> {
   final Client client;
   // Use iOS options that allow background access - will be accessible after first unlock
-  final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+  final FlutterSecureStorage secureStorage = SecureStorageProvider.instance();
   final AvatarCacheService cacheService = AvatarCacheService();
   bool _cacheInitialized = false;
 

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -27,7 +27,7 @@ import 'dart:typed_data';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:encrypt/encrypt.dart' as encrypt;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'package:grid_frontend/widgets/user_avatar.dart';
 import 'package:grid_frontend/widgets/user_avatar_bloc.dart';
 import 'package:grid_frontend/services/avatar_announcement_service.dart';
@@ -1659,7 +1659,7 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Future<void> _uploadAvatarToR2(String imagePath) async {
     final colorScheme = Theme.of(context).colorScheme;
-    final secureStorage = FlutterSecureStorage();
+    final secureStorage = SecureStorageProvider.instance();
     
     try {
       // Show subtle loading indicator
@@ -1839,7 +1839,7 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Future<void> _uploadAvatarToMatrix(String imagePath) async {
     final colorScheme = Theme.of(context).colorScheme;
-    final secureStorage = FlutterSecureStorage();
+    final secureStorage = SecureStorageProvider.instance();
     
     try {
       // Show subtle loading indicator
@@ -2009,7 +2009,7 @@ class _SettingsPageState extends State<SettingsPage> {
   Future<void> _removeAvatar() async {
     final client = Provider.of<Client>(context, listen: false);
     final userId = client.userID ?? '';
-    final secureStorage = const FlutterSecureStorage();
+    final secureStorage = SecureStorageProvider.instance();
     final avatarBloc = context.read<AvatarBloc>();
 
     try {
@@ -2083,8 +2083,8 @@ class _SettingsPageState extends State<SettingsPage> {
         _isLoadingAvatar = true;
       });
 
-      final secureStorage = FlutterSecureStorage();
-      
+      final secureStorage = SecureStorageProvider.instance();
+
       // First check if custom server (Matrix avatar)
       final prefs = await SharedPreferences.getInstance();
       final isMatrixAvatar = prefs.getBool('avatar_is_matrix') ?? false;

--- a/lib/services/avatar_announcement_service.dart
+++ b/lib/services/avatar_announcement_service.dart
@@ -1,10 +1,11 @@
 import 'package:matrix/matrix.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'dart:convert';
 
 class AvatarAnnouncementService {
   final Client client;
-  final FlutterSecureStorage secureStorage = FlutterSecureStorage();
+  final FlutterSecureStorage secureStorage = SecureStorageProvider.instance();
 
   AvatarAnnouncementService(this.client);
 

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -3,6 +3,7 @@ import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:encrypt/encrypt.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'package:grid_frontend/repositories/location_repository.dart';
 import 'package:grid_frontend/repositories/location_history_repository.dart';
 import 'package:grid_frontend/repositories/room_location_history_repository.dart';
@@ -14,7 +15,10 @@ import 'package:grid_frontend/repositories/map_icon_repository.dart';
 
 class DatabaseService {
   static Database? _database;
-  final FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+  final FlutterSecureStorage _secureStorage = SecureStorageProvider.instance();
+  // In-memory cache so a transient keychain error doesn't poison every
+  // subsequent repo read in this process.
+  String? _cachedKey;
 
   /// Get the database instance (Singleton)
   Future<Database> get database async {
@@ -67,14 +71,17 @@ class DatabaseService {
     } else {
       print('Encryption key exists.');
     }
+    _cachedKey = key;
   }
 
   /// Fetch the encryption key
   Future<String> getEncryptionKey() async {
-    String? key = await _secureStorage.read(key: 'encryptionKey');
+    if (_cachedKey != null) return _cachedKey!;
+    final key = await _secureStorage.read(key: 'encryptionKey');
     if (key == null) {
       throw Exception('Encryption key not found!');
     }
+    _cachedKey = key;
     return key;
   }
 

--- a/lib/services/message_processor.dart
+++ b/lib/services/message_processor.dart
@@ -8,6 +8,7 @@ import 'package:grid_frontend/services/user_device_status_cache.dart';
 import 'package:matrix/encryption/encryption.dart';
 import 'package:matrix/matrix.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 import 'package:encrypt/encrypt.dart' as encrypt;
@@ -36,7 +37,7 @@ class MessageProcessor {
   final LocationHistoryRepository locationHistoryRepository;
   final RoomLocationHistoryRepository? roomLocationHistoryRepository;
   final MessageParser messageParser;
-  final FlutterSecureStorage secureStorage = FlutterSecureStorage();
+  final FlutterSecureStorage secureStorage = SecureStorageProvider.instance();
   final AvatarBloc? avatarBloc;
   final MapIconSyncService? mapIconSyncService;
   final UserRepository? userRepository;

--- a/lib/services/secure_storage_provider.dart
+++ b/lib/services/secure_storage_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+// Centralized FlutterSecureStorage factory. iOS uses
+// first_unlock_this_device so background launches on a locked phone don't
+// throw -25308 ("User interaction is not allowed") and cascade into stuck
+// offline state (see Fix A).
+//
+// Migration is lazy and intentional: items previously written with the
+// default WhenUnlocked accessibility stay readable while the device is
+// unlocked, and only the next write rewrites them with the new policy.
+// No explicit migration code — that would risk losing the encryption key.
+class SecureStorageProvider {
+  static const IOSOptions _iosOptions = IOSOptions(
+    accessibility: KeychainAccessibility.first_unlock_this_device,
+  );
+
+  // Android: keep defaults — switching to encryptedSharedPreferences would
+  // strand existing on-disk values written under the old backend.
+  static FlutterSecureStorage instance() => const FlutterSecureStorage(
+        iOptions: _iosOptions,
+      );
+}

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -3,11 +3,12 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 
 class SubscriptionService {
   static const String _mapTokenKey = 'satellite_map_token';
   static const String _mapTokenExpiryKey = 'satellite_map_token_expiry';
-  final _secureStorage = FlutterSecureStorage();
+  final FlutterSecureStorage _secureStorage = SecureStorageProvider.instance();
 
   Future<bool> hasActiveSubscription() async {
     try {

--- a/lib/widgets/group_avatar.dart
+++ b/lib/widgets/group_avatar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:provider/provider.dart';
 import 'package:matrix/matrix.dart';
@@ -99,7 +99,7 @@ class _GroupAvatarState extends State<GroupAvatar> {
     });
 
     try {
-      const secureStorage = FlutterSecureStorage();
+      final secureStorage = SecureStorageProvider.instance();
       final prefs = await SharedPreferences.getInstance();
       
       // Check if it's a Matrix avatar or encrypted avatar

--- a/lib/widgets/group_avatar_bloc.dart
+++ b/lib/widgets/group_avatar_bloc.dart
@@ -7,6 +7,7 @@ import '../blocs/avatar/avatar_bloc.dart';
 import '../blocs/avatar/avatar_event.dart';
 import '../blocs/avatar/avatar_state.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:matrix/matrix.dart';
 import 'package:encrypt/encrypt.dart' as encrypt;
@@ -35,7 +36,7 @@ class GroupAvatarBloc extends StatefulWidget {
 class _GroupAvatarBlocState extends State<GroupAvatarBloc> {
   static final GroupAvatarCacheService _cacheService = GroupAvatarCacheService();
   static bool _cacheInitialized = false;
-  final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+  final FlutterSecureStorage secureStorage = SecureStorageProvider.instance();
   Uint8List? _avatarBytes;
   bool _isLoading = true;
   String? _loadedRoomId;

--- a/lib/widgets/group_profile_modal.dart
+++ b/lib/widgets/group_profile_modal.dart
@@ -14,7 +14,7 @@ import 'package:grid_frontend/blocs/groups/groups_bloc.dart';
 import 'package:grid_frontend/utilities/utils.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:image_cropper/image_cropper.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:encrypt/encrypt.dart' as encrypt;
@@ -224,9 +224,9 @@ class _GroupProfileModalState extends State<GroupProfileModal> with TickerProvid
         _isLoadingGroupAvatar = true;
       });
 
-      final secureStorage = FlutterSecureStorage();
+      final secureStorage = SecureStorageProvider.instance();
       final prefs = await SharedPreferences.getInstance();
-      
+
       // Check if it's a Matrix avatar or encrypted avatar
       final isMatrixAvatar = prefs.getBool('group_avatar_is_matrix_$roomId') ?? false;
       
@@ -615,7 +615,7 @@ class _GroupProfileModalState extends State<GroupProfileModal> with TickerProvid
         print('[Group Avatar Upload] Success! CDN URL: $cdnUrl');
         
         // Store in secure storage
-        final secureStorage = FlutterSecureStorage();
+        final secureStorage = SecureStorageProvider.instance();
         final avatarData = {
           'uri': cdnUrl,
           'key': key.base64,
@@ -693,7 +693,7 @@ class _GroupProfileModalState extends State<GroupProfileModal> with TickerProvid
       print('[Group Avatar Upload Matrix] Uploaded to: $mxcUri');
       
       // Store encryption keys in secure storage
-      final secureStorage = FlutterSecureStorage();
+      final secureStorage = SecureStorageProvider.instance();
       final avatarData = {
         'uri': mxcUri,
         'key': key.base64,

--- a/lib/widgets/user_avatar.dart
+++ b/lib/widgets/user_avatar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:grid_frontend/services/secure_storage_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:provider/provider.dart';
 import 'package:matrix/matrix.dart';
@@ -161,7 +161,7 @@ class _UserAvatarState extends State<UserAvatar> {
     }
 
     try {
-      const secureStorage = FlutterSecureStorage();
+      final secureStorage = SecureStorageProvider.instance();
       final prefs = await SharedPreferences.getInstance();
       
       // Check if it's a Matrix avatar or encrypted avatar


### PR DESCRIPTION
## Summary
- Every `FlutterSecureStorage()` constructor in the app was using default iOS accessibility (`kSecAttrAccessibleWhenUnlocked`), which fails with `-25308 User interaction is not allowed` when iOS background-launches Grid for a location wake on a locked phone.
- That single failure poisons `DatabaseService.getEncryptionKey()` and cascades — every repository read fails, avatars never decrypt, location pings can't be sent. User sees ~45 min of "stuck offline" after long background resume before things self-recover.
- This PR introduces a shared `SecureStorageProvider` factory configured with `KeychainAccessibility.first_unlock_this_device`, replaces 14 direct constructor sites across 11 files, and caches the decoded encryption key in memory inside `DatabaseService` so a single transient failure doesn't keep failing every subsequent repo call.
- libre_location's headless dispatcher hits the keychain via `DatabaseService` and automatically inherits the new accessibility — no separate change needed.

## Changelog
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Fix long background resume getting stuck loading after a location wake.

## Test plan
- [x] Analyzer clean on all 11 changed files
- [ ] TestFlight install, leave overnight, open in morning — avatars and locations load promptly, no `-25308` in logs