### PR TITLE
fix(sync): force matrix client reconnect on resume after long bg

### DIFF
--- a/changes/pr-275.md
+++ b/changes/pr-275.md
@@ -1,0 +1,1 @@
+[fix] Recover Matrix sync faster after long background suspension.

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -106,6 +106,11 @@ class SyncManager with ChangeNotifier {
   bool _firstNudgeScheduled = false;
   static const Duration _resumeNudgeThreshold = Duration(hours: 6);
 
+  // Force-reconnect on resume after long bg — iOS reclaims long-poll sockets.
+  DateTime? _lastForceReconnectAt;
+  static const Duration _forceReconnectThreshold = Duration(seconds: 60);
+  static const Duration _forceReconnectDebounce = Duration(seconds: 10);
+
 
   SyncManager(
       this.client,
@@ -405,21 +410,54 @@ class SyncManager with ChangeNotifier {
       }
       mapBloc.add(MapLoadUserLocations());
 
-      if (client.isLogged() && (!_isSyncing || !client.syncPending)) {
+      final pausedAt = _pausedTime;
+      final bgGap =
+          pausedAt != null ? DateTime.now().difference(pausedAt) : Duration.zero;
+      final didForceReconnect = _maybeForceReconnect(bgGap);
+
+      if (!didForceReconnect &&
+          client.isLogged() &&
+          (!_isSyncing || !client.syncPending)) {
         _startSyncStream();
       }
 
       // If we were paused long enough, opportunistically nudge contacts for
       // any missing avatars / stale locations.
-      final pausedAt = _pausedTime;
-      if (pausedAt != null &&
-          DateTime.now().difference(pausedAt) >= _resumeNudgeThreshold) {
+      if (pausedAt != null && bgGap >= _resumeNudgeThreshold) {
         unawaited(_runNudgePass());
       }
       _pausedTime = null;
     } else {
       _pausedTime = DateTime.now();
     }
+  }
+
+  /// Force a fresh sync stream when the long-poll socket is likely dead after
+  /// a long bg gap. Returns true if reconnect was triggered.
+  bool _maybeForceReconnect(Duration bgGap) {
+    if (bgGap < _forceReconnectThreshold) return false;
+    if (!client.isLogged()) return false;
+    if (_syncState == SyncState.loadingToken ||
+        _syncState == SyncState.performingCatchUp) {
+      return false;
+    }
+    final last = _lastForceReconnectAt;
+    if (last != null &&
+        DateTime.now().difference(last) < _forceReconnectDebounce) {
+      print('[SyncManager] resume within debounce window, skipping');
+      return false;
+    }
+    _lastForceReconnectAt = DateTime.now();
+    print(
+        '[SyncManager] resume after ${bgGap.inSeconds}s — force reconnecting');
+    try {
+      if (client.syncPending) client.abortSync();
+    } catch (_) {}
+    _syncSubscription?.cancel();
+    _syncSubscription = null;
+    _isSyncing = false;
+    unawaited(_startSyncStream());
+    return true;
   }
 
   /// Defer the cold-launch nudge pass so it doesn't pile onto the hot path.


### PR DESCRIPTION
## Summary
- After ~8 hours background, the matrix-dart-sdk's long-poll `/sync` socket is dead (iOS reclaims sockets aggressively), but `SyncManager.handleAppLifecycleState(true)` was gating the reconnect behind `!client.syncPending` — which is exactly the flag that's stale on resume.
- Result was the dead socket riding through 40s timeouts repeatedly (`Bad file descriptor`, `Connection closed`), and `Future.wait` across N parallel `sendLocationEvent` calls all stuck on the same dead pool — producing the observed 9-minute `Batch update complete in 557318ms` log.
- This PR computes the bg gap from the existing `_pausedTime`, and when it exceeds 60s force-aborts the in-flight sync and re-enters `_startSyncStream()`, regardless of `client.syncPending`. 10s debounce prevents repeated aborts on quick toggles.
- Skipped when SyncState is already `loadingToken` or `performingCatchUp` (initialize is doing its own bootstrap).

## Changelog
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Recover Matrix sync faster after long background suspension.

## Test plan
- [x] Analyzer status unchanged on `sync_manager.dart`
- [ ] TestFlight overnight, open in morning — sync recovers within seconds, no 9-minute batch hang