### PR TITLE
fix(keychain): migrate legacy items + boot recovery for missing key

### DIFF
--- a/changes/pr-277.md
+++ b/changes/pr-277.md
@@ -1,0 +1,1 @@
+[fix] Restore access for users whose encryption key was hidden by the previous keychain update.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,6 +64,7 @@ import 'package:grid_frontend/repositories/invitations_repository.dart';
 import 'package:grid_frontend/widgets/version_wrapper.dart';
 import 'package:grid_frontend/widgets/migration_modal.dart';
 import 'package:grid_frontend/widgets/in_app_notification_overlay.dart';
+import 'package:grid_frontend/widgets/key_recovery_screen.dart';
 import 'package:libre_location/libre_location.dart';
 import 'package:grid_frontend/services/debug_log_service.dart';
 import 'package:grid_frontend/services/push_notification_service.dart';
@@ -95,6 +96,14 @@ void main() async {
   // Initialize DatabaseService
   final databaseService = DatabaseService();
   await databaseService.initDatabase();
+
+  // Self-heal the post-Fix-A keychain accessibility regression: hasEncryptionKey
+  // returns true if either the new or legacy accessibility has the key and
+  // migrates legacy → new on hit. If both are empty (genuine loss), block
+  // boot on the recovery screen so the user can wipe + restart in-place.
+  if (!await databaseService.hasEncryptionKey()) {
+    await _runKeyRecoveryFlow(databaseService);
+  }
 
   await vod.init();
 
@@ -447,6 +456,33 @@ void main() async {
       },
     ),
   );
+}
+
+/// Blocks boot with a recovery UI when the encryption key is genuinely gone.
+/// `runApp` here replaces any prior tree; the completer holds main() until
+/// the user resets, after which the normal boot path proceeds and another
+/// `runApp` overwrites this one.
+Future<void> _runKeyRecoveryFlow(DatabaseService databaseService) async {
+  final completer = Completer<void>();
+  runApp(
+    AnimatedBuilder(
+      animation: ThemeController.instance,
+      builder: (context, _) => MaterialApp(
+        title: 'Grid App',
+        debugShowCheckedModeBanner: false,
+        theme: _buildTheme(GridTokens.lightScheme()),
+        darkTheme: _buildTheme(GridTokens.darkScheme()),
+        themeMode: ThemeController.instance.mode,
+        home: KeyRecoveryScreen(
+          databaseService: databaseService,
+          onResetComplete: () {
+            if (!completer.isCompleted) completer.complete();
+          },
+        ),
+      ),
+    ),
+  );
+  await completer.future;
 }
 
 /// Build the app theme from a Grid-tokenized ColorScheme.

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -13,9 +13,20 @@ import 'package:grid_frontend/repositories/sharing_preferences_repository.dart';
 import 'package:grid_frontend/repositories/user_keys_repository.dart';
 import 'package:grid_frontend/repositories/map_icon_repository.dart';
 
+/// Thrown when the encryption key can't be found under any known
+/// accessibility level. Caller (typically main.dart) shows a recovery dialog.
+class EncryptionKeyMissingException implements Exception {
+  const EncryptionKeyMissingException();
+  @override
+  String toString() => 'Encryption key not found in keychain.';
+}
+
 class DatabaseService {
   static Database? _database;
   final FlutterSecureStorage _secureStorage = SecureStorageProvider.instance();
+  // Reads only — items written before Fix A landed under the default
+  // WhenUnlocked accessibility and are invisible to [_secureStorage].
+  final FlutterSecureStorage _legacyStorage = SecureStorageProvider.legacyInstance();
   // In-memory cache so a transient keychain error doesn't poison every
   // subsequent repo read in this process.
   String? _cachedKey;
@@ -62,7 +73,7 @@ class DatabaseService {
 
   /// Ensures an encryption key exists in secure storage
   Future<void> _initializeEncryptionKey() async {
-    String? key = await _secureStorage.read(key: 'encryptionKey');
+    String? key = await _readKeyWithFallback();
     if (key == null) {
       final keyBytes = Key.fromSecureRandom(32);
       key = keyBytes.base64;
@@ -77,12 +88,57 @@ class DatabaseService {
   /// Fetch the encryption key
   Future<String> getEncryptionKey() async {
     if (_cachedKey != null) return _cachedKey!;
-    final key = await _secureStorage.read(key: 'encryptionKey');
+    final key = await _readKeyWithFallback();
     if (key == null) {
-      throw Exception('Encryption key not found!');
+      throw const EncryptionKeyMissingException();
     }
     _cachedKey = key;
     return key;
+  }
+
+  /// Returns true iff an encryption key is reachable (under either
+  /// accessibility). Side-effect: migrates legacy items to the new
+  /// accessibility when found. Safe to call at boot for health checks.
+  Future<bool> hasEncryptionKey() async {
+    if (_cachedKey != null) return true;
+    final key = await _readKeyWithFallback();
+    if (key == null) return false;
+    _cachedKey = key;
+    return true;
+  }
+
+  /// Recovery for the worst case: keychain item is genuinely gone (data
+  /// corruption, user manually wiped keychain, etc). All encrypted on-disk
+  /// data is unreadable — wipe the Grid DB and generate a fresh key.
+  /// Matrix client state and credentials are NOT touched.
+  Future<void> resetEncryptionForRecovery() async {
+    print('Resetting encryption for recovery — Grid DB will be wiped.');
+    // Clear any stale legacy item so the next read isn't ambiguous.
+    try {
+      await _legacyStorage.delete(key: 'encryptionKey');
+    } catch (_) {}
+    try {
+      await _secureStorage.delete(key: 'encryptionKey');
+    } catch (_) {}
+    _cachedKey = null;
+    await deleteAndReinitialize();
+  }
+
+  Future<String?> _readKeyWithFallback() async {
+    final primary = await _secureStorage.read(key: 'encryptionKey');
+    if (primary != null) return primary;
+    final legacy = await _legacyStorage.read(key: 'encryptionKey');
+    if (legacy == null) return null;
+    // Migrate to the new accessibility. Best effort — failure is non-fatal
+    // because the next read still finds the legacy item.
+    try {
+      await _secureStorage.write(key: 'encryptionKey', value: legacy);
+      await _legacyStorage.delete(key: 'encryptionKey');
+      print('Migrated encryption key from legacy accessibility.');
+    } catch (e) {
+      print('Encryption key migration write failed (non-fatal): $e');
+    }
+    return legacy;
   }
 
   /// Clear all data from the database

--- a/lib/services/secure_storage_provider.dart
+++ b/lib/services/secure_storage_provider.dart
@@ -2,21 +2,23 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 // Centralized FlutterSecureStorage factory. iOS uses
 // first_unlock_this_device so background launches on a locked phone don't
-// throw -25308 ("User interaction is not allowed") and cascade into stuck
-// offline state (see Fix A).
+// throw -25308 ("User interaction is not allowed").
 //
-// Migration is lazy and intentional: items previously written with the
-// default WhenUnlocked accessibility stay readable while the device is
-// unlocked, and only the next write rewrites them with the new policy.
-// No explicit migration code — that would risk losing the encryption key.
+// flutter_secure_storage 9.x puts kSecAttrAccessible IN the search query
+// (FlutterSecureStorage.swift:35), so items written under the previous
+// default (WhenUnlocked) are invisible to a read configured with
+// first_unlock_this_device. Use [legacyInstance] to read those and
+// DatabaseService migrates on hit.
 class SecureStorageProvider {
   static const IOSOptions _iosOptions = IOSOptions(
     accessibility: KeychainAccessibility.first_unlock_this_device,
   );
 
-  // Android: keep defaults — switching to encryptedSharedPreferences would
-  // strand existing on-disk values written under the old backend.
   static FlutterSecureStorage instance() => const FlutterSecureStorage(
         iOptions: _iosOptions,
       );
+
+  // Default accessibility — only used to read items written before the
+  // Fix A migration so we can move them under the new accessibility.
+  static FlutterSecureStorage legacyInstance() => const FlutterSecureStorage();
 }

--- a/lib/widgets/key_recovery_screen.dart
+++ b/lib/widgets/key_recovery_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:grid_frontend/services/database_service.dart';
+import 'package:grid_frontend/widgets/grid/grid_button.dart';
+
+/// Shown at boot when the encryption key is missing under every known
+/// accessibility level. Offers a single recovery action: wipe the local
+/// Grid DB and reset. Matrix credentials and sync state are untouched —
+/// once the user reopens the app, contacts/locations rebuild from sync.
+class KeyRecoveryScreen extends StatefulWidget {
+  const KeyRecoveryScreen({
+    super.key,
+    required this.databaseService,
+    required this.onResetComplete,
+  });
+
+  final DatabaseService databaseService;
+  final VoidCallback onResetComplete;
+
+  @override
+  State<KeyRecoveryScreen> createState() => _KeyRecoveryScreenState();
+}
+
+class _KeyRecoveryScreenState extends State<KeyRecoveryScreen> {
+  bool _resetting = false;
+  String? _error;
+
+  Future<void> _handleReset() async {
+    setState(() {
+      _resetting = true;
+      _error = null;
+    });
+    try {
+      await widget.databaseService.resetEncryptionForRecovery();
+      widget.onResetComplete();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _resetting = false;
+        _error = 'Reset failed: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 48),
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Icon(
+                  Icons.lock_reset_outlined,
+                  size: 56,
+                  color: colorScheme.primary,
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'Couldn\'t unlock your data',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'The encryption key for your local data wasn\'t found in '
+                  'the keychain. This can happen after some iOS keychain '
+                  'changes.\n\nResetting will clear your local Grid data '
+                  '(cached contacts, locations) and generate a fresh key. '
+                  'Your account and contacts rebuild from sync after reset.',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                        height: 1.4,
+                      ),
+                ),
+                if (_error != null) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    _error!,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(color: colorScheme.error),
+                  ),
+                ],
+                const SizedBox(height: 32),
+                GridButton(
+                  label: _resetting ? 'Resetting…' : 'Reset App Data',
+                  onPressed: _resetting ? null : _handleReset,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Fix A (#274) regressed existing users: `flutter_secure_storage` 9.x includes `kSecAttrAccessible` in the search query (`FlutterSecureStorage.swift:35`), so items written under the prior default `WhenUnlocked` are invisible to a read configured with `first_unlock_this_device`. Every pre-Fix-A install hit `Exception('Encryption key not found!')` from `DatabaseService.getEncryptionKey` and surfaced as "everyone offline" with no clear in-app error.
- This PR auto-migrates the 99% case (read primary → fall back to legacy → on hit, write to new accessibility, delete legacy) and adds a boot-time recovery screen for the genuinely-missing case (data corruption, manual keychain wipe).

## What changes
- `SecureStorageProvider.legacyInstance()` reads items under the default accessibility.
- `DatabaseService._readKeyWithFallback()` does primary → legacy → migrate-on-hit. Best effort; failure is non-fatal because the next read still finds the legacy item.
- `EncryptionKeyMissingException`, `hasEncryptionKey()`, `resetEncryptionForRecovery()`.
- `KeyRecoveryScreen` (new) — single "Reset App Data" button. Wipes Grid DB, generates fresh key, proceeds with normal boot in-place. Matrix credentials and sync state untouched — contacts and locations rebuild from sync.
- `main.dart` calls `hasEncryptionKey()` after `initDatabase()`; on false, blocks boot on the recovery screen.

## Changelog
- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Restore access for users whose encryption key was hidden by the previous keychain update.

## Test plan
- [x] Analyzer clean on the four touched files
- [ ] TestFlight: existing installs see contacts and locations again without any reset prompt
- [ ] TestFlight: fresh installs (no key in either accessibility) hit the recovery screen and can self-reset