### PR TITLE
fix(boot): bound boot awaits, tolerate locked keychain, repair dead sync socket

### DIFF
--- a/changes/pr-279.md
+++ b/changes/pr-279.md
@@ -1,0 +1,1 @@
+[fix] Fixed the app getting stuck on the splash screen when reopened after a long time in the background.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -65,6 +65,7 @@ import 'package:grid_frontend/widgets/version_wrapper.dart';
 import 'package:grid_frontend/widgets/migration_modal.dart';
 import 'package:grid_frontend/widgets/in_app_notification_overlay.dart';
 import 'package:grid_frontend/widgets/key_recovery_screen.dart';
+import 'package:grid_frontend/widgets/boot_error_screen.dart';
 import 'package:libre_location/libre_location.dart';
 import 'package:grid_frontend/services/debug_log_service.dart';
 import 'package:grid_frontend/services/push_notification_service.dart';
@@ -78,37 +79,71 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await ThemeController.instance.load();
+  // Every boot await is bounded: a wedged call must surface as a retryable
+  // error screen, never an eternal native splash (bg-resume hang).
+  while (true) {
+    try {
+      await _boot();
+      return;
+    } catch (e, s) {
+      debugPrint('[Boot] FATAL: $e\n$s');
+      await _runBootErrorFlow(e);
+    }
+  }
+}
+
+/// Non-fatal boot step: log + continue on error/timeout.
+Future<T?> _tryBootStep<T>(String step, Future<T> future, Duration limit) async {
+  try {
+    return await future.timeout(limit);
+  } catch (e) {
+    debugPrint('[Boot] $step failed (continuing): $e');
+    return null;
+  }
+}
+
+Future<void> _boot() async {
+  await _tryBootStep('theme', ThemeController.instance.load(), const Duration(seconds: 5));
 
   LibreLocation.registerHeadlessDispatcher(headlessDispatcher, onHeadlessLocation);
 
   // Initialize Firebase (for push notifications)
   try {
-    await Firebase.initializeApp();
+    await Firebase.initializeApp().timeout(const Duration(seconds: 10));
     debugPrint('[Push] Firebase initialized');
   } catch (e) {
     debugPrint('[Push] Firebase init failed (ok if no config): $e');
   }
 
   // Load .env file
-  await dotenv.load(fileName: ".env");
+  await _tryBootStep('dotenv', dotenv.load(fileName: ".env"), const Duration(seconds: 5));
 
   // Initialize DatabaseService
   final databaseService = DatabaseService();
-  await databaseService.initDatabase();
+  await databaseService.initDatabase().timeout(const Duration(seconds: 15));
 
   // Self-heal the post-Fix-A keychain accessibility regression: hasEncryptionKey
   // returns true if either the new or legacy accessibility has the key and
   // migrates legacy → new on hit. If both are empty (genuine loss), block
   // boot on the recovery screen so the user can wipe + restart in-place.
-  if (!await databaseService.hasEncryptionKey()) {
+  bool encryptionKeyMissing = false;
+  try {
+    encryptionKeyMissing =
+        !await databaseService.hasEncryptionKey().timeout(const Duration(seconds: 5));
+  } catch (e) {
+    // Keychain unreachable (locked device, transient error) — the key is not
+    // proven missing, so boot on instead of offering destructive recovery.
+    debugPrint('[Boot] Keychain unavailable, skipping recovery check: $e');
+  }
+  if (encryptionKeyMissing) {
     await _runKeyRecoveryFlow(databaseService);
   }
 
-  await vod.init();
+  await vod.init().timeout(const Duration(seconds: 15));
 
   // Initialize Matrix Client with backwards compatible database
-  final database = await BackwardsCompatibilityService.createMatrixDatabase();
+  final database = await BackwardsCompatibilityService.createMatrixDatabase()
+      .timeout(const Duration(seconds: 15));
   final client = Client(
     'Grid App',
     database: database,
@@ -120,7 +155,7 @@ void main() async {
     // This ensures location sharing works without requiring device verification
     shareKeysWith: ShareKeysWith.all,
   );
-  await client.init();
+  await client.init().timeout(const Duration(seconds: 30));
 
   // Only forward room keys to peers who are still a Join member of the room.
   // Refuse forwards to kicked / left / never-joined devices to avoid leaking history.
@@ -141,12 +176,13 @@ void main() async {
   });
 
   // Initialize debug logging service
-  await DebugLogService.instance.init();
+  await _tryBootStep('debugLog', DebugLogService.instance.init(), const Duration(seconds: 5));
 
   // On warm start, re-register push notifications for the restored session.
   // (client.init() restored creds from the Matrix DB; we just need pushers refreshed.)
-  final prefs = await SharedPreferences.getInstance();
-  String? token = prefs.getString('token');
+  final prefs = await _tryBootStep(
+      'prefs', SharedPreferences.getInstance(), const Duration(seconds: 5));
+  String? token = prefs?.getString('token');
 
   if (token != null && token.isNotEmpty) {
     try {
@@ -154,7 +190,11 @@ void main() async {
 
       if (client.isLogged()) {
         final pushService = PushNotificationService(client: client);
-        await pushService.register();
+        // Network call — never allowed to block first frame.
+        unawaited(pushService
+            .register()
+            .timeout(const Duration(seconds: 15))
+            .catchError((e) => debugPrint('[Push] register failed: $e')));
       }
     } catch (e) {
       print('Error restoring session with token: $e');
@@ -162,7 +202,8 @@ void main() async {
   }
 
   // Initialize notification channels (Android)
-  await NotificationChannels.createAll();
+  await _tryBootStep(
+      'notifChannels', NotificationChannels.createAll(), const Duration(seconds: 5));
 
 
   // Initialize repositories
@@ -182,13 +223,15 @@ void main() async {
   // actually stop location posts.
   final sharingStateNotifier = SharingStateNotifier();
   final locationDispatch = LocationDispatch(sharingStateNotifier);
-  await locationDispatch.start();
+  await _tryBootStep(
+      'locationDispatch', locationDispatch.start(), const Duration(seconds: 5));
 
   // Watches the user's saved home geofence and flips `sharingStateNotifier`
   // on enter/exit. Reads `home_location` + `home_radius` +
   // `auto_pause_at_home_enabled` prefs (owned by SettingsPage).
   final homeGeofenceService = HomeGeofenceService(sharingStateNotifier);
-  await homeGeofenceService.start();
+  await _tryBootStep(
+      'homeGeofence', homeGeofenceService.start(), const Duration(seconds: 5));
 
   // Initialize services
   final userService = UserService(client, locationRepository, sharingPreferencesRepository);
@@ -456,6 +499,31 @@ void main() async {
       },
     ),
   );
+}
+
+/// Blocks on a retryable error UI when a fatal boot step failed or timed out.
+/// Returning hands control back to the boot retry loop in main().
+Future<void> _runBootErrorFlow(Object error) async {
+  final completer = Completer<void>();
+  runApp(
+    AnimatedBuilder(
+      animation: ThemeController.instance,
+      builder: (context, _) => MaterialApp(
+        title: 'Grid App',
+        debugShowCheckedModeBanner: false,
+        theme: _buildTheme(GridTokens.lightScheme()),
+        darkTheme: _buildTheme(GridTokens.darkScheme()),
+        themeMode: ThemeController.instance.mode,
+        home: BootErrorScreen(
+          error: error,
+          onRetry: () {
+            if (!completer.isCompleted) completer.complete();
+          },
+        ),
+      ),
+    ),
+  );
+  await completer.future;
 }
 
 /// Blocks boot with a recovery UI when the encryption key is genuinely gone.

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -860,6 +860,8 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
         final pauseDuration = DateTime.now().difference(lastFg);
         if (pauseDuration.inSeconds > _longPauseThresholdSeconds) {
           print('[MapTab] Long pause detected (${pauseDuration.inSeconds}s) - restarting');
+          // Mark handled so the stale ts can't re-trigger another restart.
+          unawaited(_persistLastForegroundTs(DateTime.now()));
           if (mounted) {
             Navigator.of(context).pushAndRemoveUntil(
               MaterialPageRoute(
@@ -908,6 +910,8 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
       );
       if (gap.inSeconds <= _longPauseThresholdSeconds) return;
       print('[MapTab] Cold-launch long pause detected (${gap.inSeconds}s) - recovering');
+      // Mark handled so the resumed-path restart doesn't fire on the same gap.
+      unawaited(_persistLastForegroundTs(DateTime.now()));
       // Refresh avatar cache from disk.
       await AvatarCacheService().reloadFromPersistent();
       if (!mounted) return;

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -23,10 +23,16 @@ class EncryptionKeyMissingException implements Exception {
 
 class DatabaseService {
   static Database? _database;
-  final FlutterSecureStorage _secureStorage = SecureStorageProvider.instance();
+  final FlutterSecureStorage _secureStorage;
   // Reads only — items written before Fix A landed under the default
   // WhenUnlocked accessibility and are invisible to [_secureStorage].
-  final FlutterSecureStorage _legacyStorage = SecureStorageProvider.legacyInstance();
+  final FlutterSecureStorage _legacyStorage;
+
+  DatabaseService({
+    FlutterSecureStorage? secureStorage,
+    FlutterSecureStorage? legacyStorage,
+  })  : _secureStorage = secureStorage ?? SecureStorageProvider.instance(),
+        _legacyStorage = legacyStorage ?? SecureStorageProvider.legacyInstance();
   // In-memory cache so a transient keychain error doesn't poison every
   // subsequent repo read in this process.
   String? _cachedKey;
@@ -125,10 +131,28 @@ class DatabaseService {
   }
 
   Future<String?> _readKeyWithFallback() async {
-    final primary = await _secureStorage.read(key: 'encryptionKey');
+    // A read error (e.g. -25308 while the device is locked) is NOT proof of
+    // absence — rethrow it so callers never confuse "can't read" with "gone".
+    Object? readError;
+    String? primary;
+    try {
+      primary = await _secureStorage.read(key: 'encryptionKey');
+    } catch (e) {
+      print('Keychain primary read failed: $e');
+      readError = e;
+    }
     if (primary != null) return primary;
-    final legacy = await _legacyStorage.read(key: 'encryptionKey');
-    if (legacy == null) return null;
+    String? legacy;
+    try {
+      legacy = await _legacyStorage.read(key: 'encryptionKey');
+    } catch (e) {
+      print('Keychain legacy read failed: $e');
+      readError ??= e;
+    }
+    if (legacy == null) {
+      if (readError != null) throw readError;
+      return null;
+    }
     // Migrate to the new accessibility. Best effort — failure is non-fatal
     // because the next read still finds the legacy item.
     try {

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -108,8 +108,10 @@ class SyncManager with ChangeNotifier {
 
   // Force-reconnect on resume after long bg — iOS reclaims long-poll sockets.
   DateTime? _lastForceReconnectAt;
+  DateTime? _lastSyncUpdateAt;
   static const Duration _forceReconnectThreshold = Duration(seconds: 60);
   static const Duration _forceReconnectDebounce = Duration(seconds: 10);
+  static const Duration _reconnectWatchdogDelay = Duration(seconds: 15);
 
 
   SyncManager(
@@ -349,9 +351,10 @@ class SyncManager with ChangeNotifier {
   
   Future<void> _startSyncStream() async {
     if (_syncSubscription != null) return;
-    
+
     _syncSubscription = client.onSync.stream.listen(
       (syncUpdate) async {
+        _lastSyncUpdateAt = DateTime.now();
         await _processSyncUpdate(syncUpdate);
       },
       onError: (error) {
@@ -361,17 +364,31 @@ class SyncManager with ChangeNotifier {
         }
       },
     );
-    
-    // Check if the client is already syncing before starting a new sync
-    if (!client.syncPending) {
-      _isSyncing = true;
+
+    _isSyncing = true;
+    await _kickSync();
+  }
+
+  /// Fire a sync unless one is genuinely in flight. abortSync() can settle
+  /// asynchronously, so a stale `syncPending` is given a moment to clear
+  /// instead of being trusted — trusting it left `_isSyncing = true` with no
+  /// actual sync running (the post-#275 dead-socket state).
+  Future<void> _kickSync() async {
+    for (var i = 0; i < 10 && client.syncPending; i++) {
+      await Future.delayed(const Duration(milliseconds: 200));
+    }
+    if (_stopped || client.syncPending) return;
+    try {
       await client.sync(
         since: _sinceToken,
         timeout: 30000,
         setPresence: PresenceType.unavailable,
       );
-    } else {
-      _isSyncing = true;
+    } catch (e) {
+      print("[SyncManager] Kick sync failed: $e");
+      if (_isAuthenticationError(e)) {
+        await _handleAuthenticationFailure();
+      }
     }
   }
   
@@ -457,7 +474,31 @@ class SyncManager with ChangeNotifier {
     _syncSubscription = null;
     _isSyncing = false;
     unawaited(_startSyncStream());
+    _scheduleReconnectWatchdog();
     return true;
+  }
+
+  /// If no sync update lands within the watchdog window after a force
+  /// reconnect, the kick didn't take (socket still dead) — reset the debounce
+  /// and reconnect again rather than riding the dead socket forever.
+  void _scheduleReconnectWatchdog() {
+    final reconnectAt = _lastForceReconnectAt;
+    Future.delayed(_reconnectWatchdogDelay, () {
+      if (_stopped || reconnectAt == null) return;
+      if (_lastForceReconnectAt != reconnectAt) return;
+      final last = _lastSyncUpdateAt;
+      if (last != null && last.isAfter(reconnectAt)) return;
+      print('[SyncManager] reconnect watchdog: no sync update, retrying');
+      _lastForceReconnectAt = DateTime.now();
+      try {
+        if (client.syncPending) client.abortSync();
+      } catch (_) {}
+      _syncSubscription?.cancel();
+      _syncSubscription = null;
+      _isSyncing = false;
+      unawaited(_startSyncStream());
+      _scheduleReconnectWatchdog();
+    });
   }
 
   /// Defer the cold-launch nudge pass so it doesn't pile onto the hot path.

--- a/lib/widgets/boot_error_screen.dart
+++ b/lib/widgets/boot_error_screen.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:grid_frontend/widgets/grid/grid_button.dart';
+
+/// Shown when a fatal boot step failed or timed out. Offers a retry, which
+/// hands control back to the boot loop in main().
+class BootErrorScreen extends StatelessWidget {
+  const BootErrorScreen({
+    super.key,
+    required this.error,
+    required this.onRetry,
+  });
+
+  final Object error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 48),
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Icon(
+                  Icons.refresh_outlined,
+                  size: 56,
+                  color: colorScheme.primary,
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'Grid couldn\'t start',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Something went wrong while starting up. This is usually '
+                  'temporary — retrying normally fixes it.',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                        height: 1.4,
+                      ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  '$error',
+                  textAlign: TextAlign.center,
+                  maxLines: 4,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                ),
+                const SizedBox(height: 32),
+                GridButton(
+                  label: 'Retry',
+                  onPressed: onRetry,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/database_service_keychain_test.dart
+++ b/test/services/database_service_keychain_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/services/database_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  late MockSecureStorage primary;
+  late MockSecureStorage legacy;
+  late DatabaseService service;
+
+  setUp(() {
+    primary = MockSecureStorage();
+    legacy = MockSecureStorage();
+    service = DatabaseService(secureStorage: primary, legacyStorage: legacy);
+  });
+
+  PlatformException lockedKeychain() => PlatformException(
+        code: '-25308',
+        message: 'User interaction is not allowed.',
+      );
+
+  group('hasEncryptionKey', () {
+    test('true when primary store has the key', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => 'the-key');
+
+      expect(await service.hasEncryptionKey(), isTrue);
+      verifyNever(() => legacy.read(key: any(named: 'key')));
+    });
+
+    test('true + migrates when only legacy store has the key', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => null);
+      when(() => legacy.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => 'legacy-key');
+      when(() => primary.write(
+          key: 'encryptionKey',
+          value: 'legacy-key')).thenAnswer((_) async {});
+      when(() => legacy.delete(key: 'encryptionKey'))
+          .thenAnswer((_) async {});
+
+      expect(await service.hasEncryptionKey(), isTrue);
+      verify(() => primary.write(key: 'encryptionKey', value: 'legacy-key'))
+          .called(1);
+    });
+
+    test('false only when both stores cleanly report no key', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => null);
+      when(() => legacy.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => null);
+
+      expect(await service.hasEncryptionKey(), isFalse);
+    });
+
+    test('throws (not false) when primary read fails and legacy is empty',
+        () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenThrow(lockedKeychain());
+      when(() => legacy.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => null);
+
+      // A locked keychain must never be reported as "key missing" — that
+      // routes into the destructive recovery flow.
+      expect(service.hasEncryptionKey(), throwsA(isA<PlatformException>()));
+    });
+
+    test('throws when both reads fail', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenThrow(lockedKeychain());
+      when(() => legacy.read(key: 'encryptionKey'))
+          .thenThrow(lockedKeychain());
+
+      expect(service.hasEncryptionKey(), throwsA(isA<PlatformException>()));
+    });
+
+    test('still finds legacy key when primary read fails', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenThrow(lockedKeychain());
+      when(() => legacy.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => 'legacy-key');
+      when(() => primary.write(
+          key: 'encryptionKey',
+          value: 'legacy-key')).thenThrow(lockedKeychain());
+
+      // Migration write failure is non-fatal; the key was found.
+      expect(await service.hasEncryptionKey(), isTrue);
+    });
+  });
+
+  group('getEncryptionKey', () {
+    test('throws EncryptionKeyMissingException on clean absence', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => null);
+      when(() => legacy.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => null);
+
+      expect(
+        service.getEncryptionKey(),
+        throwsA(isA<EncryptionKeyMissingException>()),
+      );
+    });
+
+    test('rethrows keychain errors so -25308 queueing still works', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenThrow(lockedKeychain());
+      when(() => legacy.read(key: 'encryptionKey'))
+          .thenThrow(lockedKeychain());
+
+      expect(service.getEncryptionKey(), throwsA(isA<PlatformException>()));
+    });
+
+    test('caches the key after first successful read', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => 'the-key');
+
+      expect(await service.getEncryptionKey(), 'the-key');
+      expect(await service.getEncryptionKey(), 'the-key');
+      verify(() => primary.read(key: 'encryptionKey')).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## What changed

Fixes the splash-screen hang on bg-resume after long inactivity (iOS terminates the process, reopen is a cold launch through `main()`). Three root causes, all fixed:

1. **Locked-keychain reads crashed boot silently.** `_readKeyWithFallback()` didn't catch keychain errors, so a -25308 ("User interaction is not allowed", typical for SLC background relaunches on a locked device) bubbled out of `hasEncryptionKey()` and killed `main()` behind the native splash. Worse: an error could read as "key missing" and route into the **DB-wiping recovery flow**. Read errors are now rethrown distinctly from clean absence; boot skips the recovery check when the keychain is unreachable. `getEncryptionKey()` still rethrows `PlatformException` so the existing -25308 message queueing in SyncManager keeps working.
2. **Unbounded boot awaits.** Every fatal step in `main()` (`initDatabase`, `vod.init`, `client.init`, matrix DB) now has a timeout and surfaces a retryable `BootErrorScreen` instead of an eternal splash. Non-critical steps (dotenv, Firebase, prefs, notification channels, geofence start) log and continue. `pushService.register()` — a network call — no longer blocks first frame.
3. **Fix B dead-socket race (#275 follow-up).** `client.abortSync()` settles asynchronously; `_startSyncStream` trusted a stale `syncPending=true`, set `_isSyncing = true`, and never fired a sync — dead socket forever, and the resume gate `(!_isSyncing || !client.syncPending)` could never repair it. The sync kick now waits out stale `syncPending` before firing, and a 15s watchdog re-reconnects if no sync update lands after a force reconnect.

Also: MapTab long-pause recovery now refreshes the persisted `last_foreground_at_epoch_ms` so the same stale gap can't trigger duplicate restarts (cold-launch hook + resumed-path restart double-firing).

## Tests
- New: `test/services/database_service_keychain_test.dart` (9 tests covering error-vs-absence semantics, migration, caching)
- Full suite: 471/471 pass; `flutter analyze` clean on changed files

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed the app getting stuck on the splash screen when reopened after a long time in the background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
