### PR TITLE
chore(deps): bump libre_location to ^0.4.0 (battery profile)

### DIFF
--- a/changes/pr-281.md
+++ b/changes/pr-281.md
@@ -1,0 +1,1 @@
+[improvement] Significantly reduced battery usage with smarter motion-aware location tracking.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1083,10 +1083,10 @@ packages:
     dependency: "direct main"
     description:
       name: libre_location
-      sha256: "5e052dee026d034c3fae56e96231c9ae4b820989a053a75dd7355369028071d2"
+      sha256: c95b01f59678c49f9242ce662e31939d24345f9a80f27de402f1e5ab0a4bb2e0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   flutter_bloc: ^8.1.6
   collection: ^1.18.0
   equatable: ^2.0.7
-  libre_location: ^0.3.0
+  libre_location: ^0.4.0
   hive: ^2.2.3
   qr_code_scanner_plus: ^2.0.6
   package_info_plus: ^8.1.2


### PR DESCRIPTION
## What changed

Bumps `libre_location` 0.3.0 → 0.4.0 (published to pub.dev via the plugin's release workflow, Rezivure/libre-location#12). The new iOS power behaviors activate with no Grid-side code changes — they default on, and Grid's presets already set `pausesLocationUpdatesAutomatically`:

- Motion-driven GPS re-arming via CMMotionActivity when stationary
- Speed-adaptive accuracy while driving (NearestTenMeters ≥10 m/s, hysteresis)
- Low-battery SLC-only mode (≤20% and not charging; restores on charge/25%)
- Native pause (`pausesLocationUpdatesAutomatically`) now folds into stationary mode instead of silently stalling updates
- Upgrade-safe persisted tracking config (plugin upgrades no longer break tracking restore after termination)

On-device acceptance still to verify: zero GPS samples with phone on table 30 min, ~50m emission cadence in car, ≤3%/24h battery attribution.

## Tests
- `flutter test`: full suite passes with 0.4.0 resolved
- `flutter analyze`: no new issues

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [ ] `fix` — Bug fix
- [x] `improvement` — Enhancement

**Release note:**
Significantly reduced battery usage with smarter motion-aware location tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
