### PR TITLE
fix(e2ee): fail-open key forwards, re-request keys on decrypt failure, relax legacy rotation

### DIFF
--- a/changes/pr-283.md
+++ b/changes/pr-283.md
@@ -1,0 +1,1 @@
+[fix] Fixed contacts occasionally getting stuck on an old location due to encryption key delivery failures.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -157,21 +157,48 @@ Future<void> _boot() async {
   );
   await client.init().timeout(const Duration(seconds: 30));
 
-  // Only forward room keys to peers who are still a Join member of the room.
-  // Refuse forwards to kicked / left / never-joined devices to avoid leaking history.
+  // Forward room keys unless the requester has positively left / been banned.
+  // Fail-open: Grid rooms only carry current location (no history worth
+  // protecting), while a refused forward strands a joined peer undecryptable.
   client.onRoomKeyRequest.stream.listen((request) async {
+    final room = request.room;
+    final requestingUserId = request.requestingDevice.userId;
     try {
-      final room = request.room;
-      final requestingUserId = request.requestingDevice.userId;
-      final participants = await room.requestParticipants([Membership.join]);
-      final stillMember = participants.any((p) => p.id == requestingUserId);
-      if (!stillMember) {
-        Logs().w('[KeyForward] Refusing forward to non-member $requestingUserId in ${room.id}');
+      Membership? membership = room
+          .getState(EventTypes.RoomMember, requestingUserId)
+          ?.asUser(room)
+          .membership;
+      if (membership == null) {
+        final participants = await room.requestParticipants([
+          Membership.join,
+          Membership.invite,
+          Membership.knock,
+          Membership.leave,
+          Membership.ban,
+        ]).timeout(const Duration(seconds: 5));
+        for (final p in participants) {
+          if (p.id == requestingUserId) {
+            membership = p.membership;
+            break;
+          }
+        }
+      }
+      if (membership == Membership.leave || membership == Membership.ban) {
+        Logs().w(
+            '[KeyForward] Refusing forward to ${membership!.name} member $requestingUserId in ${room.id}');
         return;
       }
+      Logs().i(
+          '[KeyForward] Forwarding key to $requestingUserId in ${room.id} (membership: ${membership?.name ?? 'unknown'})');
       await request.forwardKey();
     } catch (e) {
-      Logs().w('[KeyForward] Failed to forward room key: $e');
+      // Stale local state or a flaky membership query must not strand a peer.
+      Logs().w('[KeyForward] Membership check failed ($e), forwarding anyway');
+      try {
+        await request.forwardKey();
+      } catch (e2) {
+        Logs().w('[KeyForward] Failed to forward room key: $e2');
+      }
     }
   });
 

--- a/lib/services/message_processor.dart
+++ b/lib/services/message_processor.dart
@@ -50,6 +50,10 @@ class MessageProcessor {
   /// Callback for when decryption fails
   DecryptionErrorCallback? _onDecryptionError;
 
+  // Per-session cooldown for explicit megolm key re-requests.
+  final Map<String, DateTime> _keyRequestedAt = {};
+  static const Duration _keyRequestCooldown = Duration(minutes: 5);
+
   MessageProcessor(
       this.locationRepository,
       this.locationHistoryRepository,
@@ -71,6 +75,27 @@ class MessageProcessor {
   /// Set a callback to be notified of decryption errors
   void setDecryptionErrorCallback(DecryptionErrorCallback callback) {
     _onDecryptionError = callback;
+  }
+
+  /// Explicitly ask peer devices for the missing megolm session. The SDK's
+  /// auto-request only consults online key backup (which Grid doesn't use),
+  /// so without this no m.room_key_request ever goes out on decrypt failure.
+  void _maybeRequestSessionKey(Room room, Event failedEvent) {
+    if (failedEvent.content['can_request_session'] != true) return;
+    final sessionId = failedEvent.content.tryGet<String>('session_id');
+    final senderKey = failedEvent.content.tryGet<String>('sender_key');
+    if (sessionId == null || senderKey == null) return;
+    final ident = '${room.id}|$sessionId';
+    final last = _keyRequestedAt[ident];
+    if (last != null &&
+        DateTime.now().difference(last) < _keyRequestCooldown) {
+      return;
+    }
+    _keyRequestedAt[ident] = DateTime.now();
+    print('[MessageProcessor] Requesting megolm session $sessionId for ${room.id}');
+    room.requestSessionKey(sessionId, senderKey).catchError((e) {
+      print('[MessageProcessor] Session key request failed: $e');
+    });
   }
 
   /// Process a single event from a room. Decrypt if necessary,
@@ -98,6 +123,7 @@ class MessageProcessor {
         decryptedEvent.content['msgtype'] == 'm.bad.encrypted') {
       print('[MessageProcessor] ⚠️ DECRYPTION FAILED for event from ${finalEvent.senderId}');
       _onDecryptionError?.call(finalEvent.senderId ?? 'unknown', roomId);
+      _maybeRequestSessionKey(room, decryptedEvent);
     }
 
     // Check if the decrypted event is now a message

--- a/lib/services/room_service.dart
+++ b/lib/services/room_service.dart
@@ -130,6 +130,38 @@ class RoomService {
     return client.homeserver.toString();
   }
 
+  /// One-time pass: rooms created before relaxed rotation landed still run
+  /// the megolm defaults (100 msgs / 1 week), so busy location rooms mint a
+  /// fresh session every ~100 posts and every member must receive it again —
+  /// a recurring source of "unable to decrypt". Align them with new rooms.
+  /// Only rooms where we hold the power level (creator) can be updated; the
+  /// other side migrates theirs when they run this build.
+  Future<void> relaxLegacyRoomRotation() async {
+    final prefs = await SharedPreferences.getInstance();
+    const flag = 'megolm_rotation_relaxed_v1';
+    if (prefs.getBool(flag) == true) return;
+    for (final room in client.rooms) {
+      if (room.membership != Membership.join) continue;
+      if (!(room.name).startsWith('Grid:')) continue;
+      try {
+        final enc = room.getState(EventTypes.Encryption)?.content;
+        if (enc == null) continue;
+        final msgs = enc['rotation_period_msgs'];
+        if (msgs is int && msgs >= 1000000000) continue;
+        if (!room.canChangeStateEvent(EventTypes.Encryption)) continue;
+        await client.setRoomStateWithKey(room.id, EventTypes.Encryption, '', {
+          'algorithm': enc['algorithm'] ?? 'm.megolm.v1.aes-sha2',
+          'rotation_period_ms': 31536000000,
+          'rotation_period_msgs': 1000000000,
+        });
+        print('[RoomService] Relaxed megolm rotation for ${room.id}');
+      } catch (e) {
+        print('[RoomService] Rotation relax failed for ${room.id}: $e');
+      }
+    }
+    await prefs.setBool(flag, true);
+  }
+
  /// create direct grid room (contact)
   /// Caller is responsible for verifying the user exists before invoking.
   Future<bool> createRoomAndInviteContact(String matrixUserId) async {

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -299,6 +299,7 @@ class SyncManager with ChangeNotifier {
       _setSyncState(SyncState.ready);
       await _processQueuedOperations();
       _scheduleFirstStartupNudge();
+      unawaited(roomService.relaxLegacyRoomRotation());
     } catch (e) {
       print("[SyncManager] Error during initialization: $e");
       _setSyncState(SyncState.error);


### PR DESCRIPTION
## What changed

Fixes the intermittent "unable to decrypt" on incoming location events. Stacked on #279 (both touch `main.dart`); auto-retargets to `main` when that merges. Root causes verified against matrix-dart-sdk 4.0.0 source:

1. **Recipients never asked for missing keys.** On decrypt failure the SDK calls `maybeAutoRequest(..., onlineKeyBackupOnly: true)` — it only consults online key backup (which Grid doesn't use) and never sends `m.room_key_request` to peer devices. `MessageProcessor` now explicitly fires `room.requestSessionKey()` on `m.bad.encrypted`, with a 5-minute per-session cooldown.
2. **`onRoomKeyRequest` over-refused.** The SDK auto-forwards to devices already in the session's `allowedAtIndex`; only new/unknown devices (the "new phone" case) reach our handler — which fail-closed on stale local state or any query error. Now fail-open: refuse only a positive `leave`/`ban`, read local member state first with a bounded (5s) server query as fallback, and forward on error. Grid rooms carry only current location, so over-forwarding is low-risk while a refused forward strands a contact.
3. **Legacy rooms still rotate megolm every 100 messages.** New rooms already set ~never-rotate (1B msgs); rooms created before that still run the default, so busy location rooms re-mint + re-share a session every ~100 posts. One-time migration (`relaxLegacyRoomRotation`, prefs-flagged) updates `m.room.encryption` rotation on joined Grid rooms where we hold PL 100; the other member's client migrates theirs when they update.

Not changed: OTK replenishment — the SDK already tops up to ⅔ of max on every sync, so exhaustion only happens for senders that never sync (fixed by #279's sync repair).

## Tests
- Full suite: 471/471 pass; `flutter analyze` clean on changed files

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed contacts occasionally getting stuck on an old location due to encryption key delivery failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

