### PR TITLE
fix: Updated https://get.grid.lat URLs (expired domain) to https://mygrid.app

### DIFF
--- a/lib/widgets/add_friend_modal.dart
+++ b/lib/widgets/add_friend_modal.dart
@@ -687,7 +687,7 @@ class _AddFriendModalState extends State<AddFriendModal>
           ? myUserId
           : '@${utils.localpart(myUserId)}';
       final message =
-          'Join me on Grid! Download it at https://get.grid.lat and send $handle a friend request!';
+          'Join me on Grid! Download it at https://mygrid.app and send $handle a friend request!';
 
       final box = context.findRenderObject() as RenderBox?;
       await Share.share(

--- a/lib/widgets/add_group_member_modal.dart
+++ b/lib/widgets/add_group_member_modal.dart
@@ -99,7 +99,7 @@ class _AddGroupMemberModalState extends State<AddGroupMemberModal>
   void _shareGroupInvite() async {
     try {
       final groupName = widget.groupName ?? 'our group';
-      final message = 'Join me on Grid! Download it at https://get.grid.lat and share your username to get invited to the $groupName group!';
+      final message = 'Join me on Grid! Download it at https://mygrid.app and share your username to get invited to the $groupName group!';
 
       await Share.share(
         message,

--- a/lib/widgets/contacts_subscreen.dart
+++ b/lib/widgets/contacts_subscreen.dart
@@ -870,7 +870,7 @@ class ContactsSubscreenState extends State<ContactsSubscreen> with TickerProvide
     try {
       final box = context.findRenderObject() as RenderBox?;
       await Share.share(
-        'Join me on Grid! Download it at https://get.grid.lat and send $handle a friend request!',
+        'Join me on Grid! Download it at https://mygrid.app and send $handle a friend request!',
         subject: 'Join me on Grid: Private Location Sharing!',
         sharePositionOrigin:
             box != null ? box.localToGlobal(Offset.zero) & box.size : null,


### PR DESCRIPTION
## What changed
Currently `Rezivure/Grid-Mobile` references https://get.grid.lat domain 3 times. It previously redirected the user to https://mygrid.app with status code 302 Found, but the domain has expired. My PR updates those links to lead to https://mygrid.app instead.

## Changelog
<!-- Check one and write a one-liner if user-facing -->

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

Updated https://get.grid.lat URLs to https://mygrid.app.

**Release note:**
Updated https://get.grid.lat URLs to https://mygrid.app.

