### PR TITLE
fix(splash): follow in-app theme instead of system brightness

### DIFF
--- a/changes/pr-288.md
+++ b/changes/pr-288.md
@@ -1,0 +1,1 @@
+[fix] Splash screen now follows your in-app theme instead of the system light/dark setting.

--- a/lib/widgets/app_initializer.dart
+++ b/lib/widgets/app_initializer.dart
@@ -4,6 +4,8 @@ import 'package:matrix/matrix.dart';
 import '../screens/onboarding/welcome_screen.dart';
 import '../screens/onboarding/splash_screen.dart';
 import '../screens/map/map_tab.dart';
+import '../services/theme_controller.dart';
+import '../styles/tokens.dart';
 
 class AppInitializer extends StatefulWidget {
   final Client client;
@@ -86,13 +88,15 @@ class _AppInitializerState extends State<AppInitializer>
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
+    // Honor the in-app theme, not system brightness, for the splash background.
+    final mode = ThemeController.instance.mode;
+    final isDark = mode == ThemeMode.dark ||
+        (mode == ThemeMode.system &&
+            MediaQuery.platformBrightnessOf(context) == Brightness.dark);
+    final scheme = isDark ? GridTokens.darkScheme() : GridTokens.lightScheme();
 
-    // Show nothing - just an empty container while we check auth
-    // The native splash will still be showing
     return Container(
-      color: colorScheme.surface,
+      color: scheme.surface,
     );
   }
 }


### PR DESCRIPTION
## What changed

The early Flutter splash background (`AppInitializer`) derived its color from `Theme.of(context).colorScheme.surface`, which MaterialApp resolves against system brightness when `themeMode` is `ThemeMode.system`, and is subject to first-frame resolution. This made the splash follow the OS light/dark setting instead of the in-app theme.

The fix resolves `ThemeController.instance.mode` directly to a brightness (explicit Dark/Light forces that brightness; `system` falls back to platform brightness) and paints the matching `GridTokens` scheme surface. A Dark in-app setting now renders a dark splash even when the phone is in Light mode.

Note: the native launch screen (flutter_native_splash `-night` resources / Android `LaunchTheme`) renders before Flutter starts and cannot read the in-app setting; that brief pre-Flutter flash is a separate concern and intentionally left out of scope.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Splash screen now follows your in-app theme instead of the system light/dark setting.
