### PR TITLE
fix(groups): show geocoded address on member rows

### DIFF
--- a/changes/pr-289.md
+++ b/changes/pr-289.md
@@ -1,0 +1,1 @@
+[fix] Group members now show their location as an address, matching the People view.

--- a/lib/widgets/group_details_subscreen.dart
+++ b/lib/widgets/group_details_subscreen.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
 import 'package:grid_frontend/services/in_app_notifier.dart';
+import 'package:grid_frontend/services/local_geocoder.dart';
 import 'package:grid_frontend/widgets/custom_search_bar.dart';
 import 'package:grid_frontend/providers/selected_subscreen_provider.dart';
 import 'package:grid_frontend/providers/user_location_provider.dart';
@@ -76,6 +77,9 @@ class _GroupDetailsSubscreenState extends State<GroupDetailsSubscreen>
   String? _currentUserId;
   Timer? _refreshTimer;
   Timer? _expiryTicker;
+
+  final Map<String, String?> _placeCache = {};
+  final Set<String> _placeInflight = {};
 
   late AnimationController _fadeController;
   late Animation<double> _fadeAnimation;
@@ -831,6 +835,16 @@ class _GroupDetailsSubscreenState extends State<GroupDetailsSubscreen>
     final name = user.displayName ?? localpart(user.userId);
 
     final isInvited = memberStatus == 'invite';
+
+    String? place;
+    if (!isInvited && userLocation != null) {
+      place = _cachedPlace(userLocation.latitude, userLocation.longitude);
+      if (place == null &&
+          !_placeCache.containsKey(
+              _placeKey(userLocation.latitude, userLocation.longitude))) {
+        _ensurePlaceFor(userLocation.latitude, userLocation.longitude);
+      }
+    }
     // Dot is freshness-only; invited members get idle (the INVITED pill
     // carries the membership semantic).
     final avatarStatus =
@@ -847,7 +861,7 @@ class _GroupDetailsSubscreenState extends State<GroupDetailsSubscreen>
       name: name,
       handle: handle,
       userId: user.userId,
-      placeLine: _placeLine(timeAgoText, isInvited),
+      placeLine: _placeLine(timeAgoText, isInvited, place: place),
       timeText: isInvited ? null : timeAgoText,
       distanceText: null,
       statusKind: statusKind,
@@ -860,10 +874,38 @@ class _GroupDetailsSubscreenState extends State<GroupDetailsSubscreen>
     );
   }
 
-  String? _placeLine(String timeAgoText, bool isInvited) {
+  String? _placeLine(String timeAgoText, bool isInvited, {String? place}) {
     if (isInvited) return 'Invite pending';
+    if (place != null && place.isNotEmpty) return place;
     if (timeAgoText == 'Offline') return "Hasn't shared yet";
     return 'Sharing location';
+  }
+
+  String _placeKey(double lat, double lng) {
+    final a = (lat * 1000).round();
+    final b = (lng * 1000).round();
+    return '$a,$b';
+  }
+
+  void _ensurePlaceFor(double lat, double lng) {
+    final key = _placeKey(lat, lng);
+    if (_placeCache.containsKey(key) || _placeInflight.contains(key)) return;
+    _placeInflight.add(key);
+    LocalGeocoder.instance.lookup(lat, lng).then((name) {
+      if (!mounted) return;
+      setState(() {
+        _placeCache[key] = name;
+        _placeInflight.remove(key);
+      });
+    }).catchError((_) {
+      if (!mounted) return;
+      _placeCache[key] = null;
+      _placeInflight.remove(key);
+    });
+  }
+
+  String? _cachedPlace(double lat, double lng) {
+    return _placeCache[_placeKey(lat, lng)];
   }
 
   bool _isRecentlyActive(DateTime? lastUpdateAt) =>


### PR DESCRIPTION
## What changed

Group member rows now reverse-geocode each member's latest location into a human-readable address, matching the People/contacts view. Previously they always rendered the literal "Sharing location" string.

The fix reuses the existing `LocalGeocoder.instance.lookup` service and mirrors the People subscreen's per-screen place cache + inflight-guard pattern (`_placeCache`/`_placeInflight`/`_ensurePlaceFor`/`_cachedPlace`/`_placeKey`), so there is no geocode call per rebuild. Members already had their `UserLocation` (lat/lng) available in `_buildMemberRow` via `UserLocationProvider`; the geocode was simply never wired. `_placeLine` now prefers the resolved place and falls back to the prior strings.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Group members now show their location as an address, matching the People view.
