### PR TITLE
fix(rooms): keep pending direct invite rooms during cleanup

### DIFF
--- a/changes/pr-290.md
+++ b/changes/pr-290.md
@@ -1,0 +1,1 @@
+[fix] Accepting a friend request now reliably adds the contact even when you already share a group.

--- a/lib/services/room_service.dart
+++ b/lib/services/room_service.dart
@@ -479,12 +479,17 @@ class RoomService {
             
             // Get joined members only
             final joinedMembers = participants.where((p) => p.membership == Membership.join).toList();
-            
-            // For direct rooms, if you're alone, leave
+            // Pending peer (outgoing/incoming request not yet accepted) — must not be reaped.
+            final hasPendingPeer = participants.any(
+                (p) => p.id != myUserId && p.membership == Membership.invite);
+
+            // For direct rooms, if you're alone, leave — but keep rooms with a pending invite.
             if (joinedMembers.length == 1 && joinedMembers.first.id == myUserId) {
-              shouldLeave = true;
-              leaveReason = 'alone in direct room - other user left';
-            } else if (joinedMembers.isEmpty) {
+              if (!hasPendingPeer) {
+                shouldLeave = true;
+                leaveReason = 'alone in direct room - other user left';
+              }
+            } else if (joinedMembers.isEmpty && !hasPendingPeer) {
               // No one has join status
               shouldLeave = true;
               leaveReason = 'no active participants in direct room';

--- a/test/repositories/user_repository_test.dart
+++ b/test/repositories/user_repository_test.dart
@@ -252,6 +252,38 @@ void main() {
       )).called(1);
     });
 
+    test('insertUserRelationship direct room coexists with existing group relationship', () async {
+      // A user already in a shared group gets a direct relationship in a
+      // DIFFERENT room. The (userId, roomId) lookup must not match the group
+      // row, so the direct relationship is inserted (not overwritten).
+      when(() => mockDatabase.query(
+        any(),
+        where: any(named: 'where'),
+        whereArgs: ['user1', 'directRoom'],
+      )).thenAnswer((_) async => []); // No existing row for the direct room
+
+      when(() => mockDatabase.insert(any(), any())).thenAnswer((_) async => 1);
+
+      // Act
+      await repository.insertUserRelationship('user1', 'directRoom', true);
+
+      // Assert: a new direct row is inserted, scoped to the direct room only.
+      verify(() => mockDatabase.query(
+        'UserRelationships',
+        where: 'userId = ? AND roomId = ?',
+        whereArgs: ['user1', 'directRoom'],
+      )).called(1);
+      verify(() => mockDatabase.insert(
+        'UserRelationships',
+        {
+          'userId': 'user1',
+          'roomId': 'directRoom',
+          'isDirect': 1,
+          'membershipStatus': null,
+        },
+      )).called(1);
+    });
+
     test('updateMembershipStatus updates correct row', () async {
       // Arrange
       when(() => mockDatabase.update(


### PR DESCRIPTION
## What changed
`RoomService.cleanRooms()` was reaping `Grid:Direct:` rooms whenever the only **joined** member was yourself — but a direct room with an outgoing/incoming friend request that hasn't been accepted yet legitimately has the peer in `invite` (not `join`) membership. On the next app launch the cleanup pass left and forgot that room and deleted the direct `UserRelationship`, destroying the pending contact before the peer ever accepted.

When you already shared a group with that user, the user record survived (it wasn't orphan-cleaned, since they were still in the group), so the symptom was specifically that the *direct contact* disappeared while the person remained reachable via the group — exactly the reported bug.

Fix: in `cleanRooms()`, treat a direct room with a pending peer (`membership == invite`) as active and do not leave it. Cleanup of genuinely abandoned direct rooms (peer left / no members) is unchanged, so the leave/kick/orphan paths still remove users only when they have neither a direct room nor a shared group.

Added a `UserRepository` unit test asserting a direct relationship is inserted in its own room and does not collide with an existing group relationship for the same user (a user can be both a direct contact and a group co-member).

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Accepting a friend request now reliably adds the contact even when you already share a group.
