### PR TITLE
fix(profile): color battery pill + last-seen by real status

### DIFF
--- a/changes/pr-291.md
+++ b/changes/pr-291.md
@@ -1,0 +1,1 @@
+[fix] Battery indicator and last-seen time now show their real status with color instead of always grey.

--- a/lib/services/android_background_task.dart
+++ b/lib/services/android_background_task.dart
@@ -28,16 +28,35 @@ void onHeadlessLocation(Map<String, dynamic> data) async {
   final double? latitude = data['latitude']?.toDouble();
   final double? longitude = data['longitude']?.toDouble();
   final double? accuracy = data['accuracy']?.toDouble();
+  final double? speed = data['speed']?.toDouble();
+  final double? heading = data['heading']?.toDouble();
   final int? timestamp = data['timestamp']?.toInt();
   final bool? isMoving = data['isMoving'] as bool?;
-  
+
+  // Battery arrives either nested ('battery': {level 0-1, charging}) or as
+  // top-level native keys ('batteryLevel' 0-100 int, 'isCharging').
+  double? batteryLevel;
+  bool? isCharging;
+  final battery = data['battery'];
+  if (battery is Map) {
+    batteryLevel = (battery['level'] as num?)?.toDouble();
+    isCharging = battery['charging'] as bool?;
+  } else if (data['batteryLevel'] != null) {
+    batteryLevel = (data['batteryLevel'] as num).toDouble() / 100.0;
+    isCharging = data['isCharging'] as bool?;
+  }
+
   if (latitude != null && longitude != null) {
     await processBackgroundLocation(
-      latitude, 
-      longitude, 
+      latitude,
+      longitude,
       accuracy ?? 0.0,
       DateTime.fromMillisecondsSinceEpoch(timestamp ?? DateTime.now().millisecondsSinceEpoch),
       isMoving ?? false,
+      speed: speed,
+      heading: heading,
+      batteryLevel: batteryLevel,
+      isCharging: isCharging,
     );
   } else {
     print('[HeadlessTask] ⚠️  Invalid location data received');
@@ -45,12 +64,16 @@ void onHeadlessLocation(Map<String, dynamic> data) async {
 }
 
 Future<void> processBackgroundLocation(
-  double latitude, 
-  double longitude, 
+  double latitude,
+  double longitude,
   double accuracy,
   DateTime timestamp,
-  bool isMoving,
-) async {
+  bool isMoving, {
+  double? speed,
+  double? heading,
+  double? batteryLevel,
+  bool? isCharging,
+}) async {
   try {
     // Reuse cached instances if available
     if (_cachedClient == null) {
@@ -113,7 +136,16 @@ Future<void> processBackgroundLocation(
         if (joinedMembers.length > 1) {
           if (!await _checkSharingWindow(room, joinedMembers, _cachedClient!, userService)) continue;
 
-          await _sendLocationUpdate(room, latitude, longitude, accuracy);
+          await _sendLocationUpdate(
+            room,
+            latitude,
+            longitude,
+            accuracy,
+            speed: speed,
+            heading: heading,
+            batteryLevel: batteryLevel,
+            isCharging: isCharging,
+          );
         } else {
           print("Grid: Skipping room ${room.id} - insufficient members");
         }
@@ -190,20 +222,40 @@ Future<bool> _checkSharingWindow(Room room, List<User> joinedMembers, Client cli
   return true;
 }
 
-Future<void> _sendLocationUpdate(Room room, double latitude, double longitude, double accuracy) async {
+Future<void> _sendLocationUpdate(
+  Room room,
+  double latitude,
+  double longitude,
+  double accuracy, {
+  double? speed,
+  double? heading,
+  double? batteryLevel,
+  bool? isCharging,
+}) async {
   // Filter out low-accuracy locations to save battery and improve quality
   if (accuracy > 100) {
     print("Grid: ⚠️  Skipping low-accuracy location for ${room.name}: ${accuracy.toStringAsFixed(1)}m error");
     return;
   }
 
-  final eventContent = {
+  // gridv 2 payload so background updates carry battery/speed too.
+  final eventContent = <String, dynamic>{
     'msgtype': 'm.location',
     'body': 'Current location',
     'geo_uri': 'geo:$latitude,$longitude',
     'description': 'Current location',
     'timestamp': DateTime.now().toUtc().toIso8601String(),
+    'gridv': 2,
+    'accuracy': accuracy,
+    if (speed != null) 'speed': speed,
+    if (heading != null) 'heading': heading,
   };
+  if (batteryLevel != null) {
+    eventContent['battery'] = <String, dynamic>{
+      'level': batteryLevel,
+      if (isCharging != null) 'charging': isCharging,
+    };
+  }
 
   await room.sendEvent(eventContent);
   print("Grid: Location event sent to room ${room.id} / ${room.name} (accuracy: ${accuracy.toStringAsFixed(1)}m)");

--- a/lib/utilities/time_ago_formatter.dart
+++ b/lib/utilities/time_ago_formatter.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 
+/// Freshness band for a last-seen timestamp, palette-agnostic so callers
+/// can map it onto their own theme tokens (and so it's unit-testable).
+enum FreshnessBand { fresh, recent, stale, offline }
+
 class TimeAgoFormatter {
   static String format(String? timestamp) {
     if (timestamp == null || timestamp == 'Offline') {
@@ -33,6 +37,24 @@ class TimeAgoFormatter {
     } catch (e) {
       print("Error parsing timestamp: $e");
       return 'Offline';
+    }
+  }
+
+  /// Pure freshness classifier used to color the last-seen pill. Mirrors
+  /// [format]'s thresholds: < 15m fresh, < 1h recent, < 24h stale, else offline.
+  static FreshnessBand bandFor(String? timestamp) {
+    if (timestamp == null || timestamp == 'Offline') return FreshnessBand.offline;
+    try {
+      final lastSeen = DateTime.parse(timestamp).toLocal();
+      final now = DateTime.now();
+      if (lastSeen.isAfter(now)) return FreshnessBand.offline;
+      final diff = now.difference(lastSeen);
+      if (diff.inMinutes < 15) return FreshnessBand.fresh;
+      if (diff.inHours < 1) return FreshnessBand.recent;
+      if (diff.inHours < 24) return FreshnessBand.stale;
+      return FreshnessBand.offline;
+    } catch (_) {
+      return FreshnessBand.offline;
     }
   }
 

--- a/lib/widgets/contact_profile_modal.dart
+++ b/lib/widgets/contact_profile_modal.dart
@@ -813,6 +813,7 @@ class _ContactProfileModalState extends State<ContactProfileModal> {
     final loc = Provider.of<UserLocationProvider>(context, listen: false)
         .getUserLocation(widget.contact.userId);
     final updatedLabel = _formatFreshness(loc?.timestamp);
+    final freshness = TimeAgoFormatter.bandFor(loc?.timestamp);
 
     // gridv 2: pull live device-status (motion / speed / battery) from
     // the cache for the contact (not the local user). Subscribe so the
@@ -833,7 +834,7 @@ class _ContactProfileModalState extends State<ContactProfileModal> {
           level: status?.batteryLevel,
           charging: status?.isCharging ?? false,
         ),
-        _MonoPill(label: updatedLabel),
+        _FreshnessPill(label: updatedLabel, band: freshness),
       ],
     );
   }
@@ -2123,23 +2124,40 @@ class _BatteryStatusPill extends StatelessWidget {
   }
 }
 
-/// Small mono pill (matches the "updated 12s" / "0.4 mi · NE" surface pills
-/// in the design — text3 on surface2 with a hairline outline).
-class _MonoPill extends StatelessWidget {
-  const _MonoPill({required this.label});
+/// Last-seen pill colored by freshness: mint (fresh) → amber (recent) →
+/// danger (stale) → muted text3 (offline / never). Grey only when truly stale.
+class _FreshnessPill extends StatelessWidget {
+  const _FreshnessPill({required this.label, required this.band});
 
   final String label;
+  final FreshnessBand band;
 
   @override
   Widget build(BuildContext context) {
+    final c = context.gridColors;
+    final Color color;
+    switch (band) {
+      case FreshnessBand.fresh:
+        color = c.mint;
+        break;
+      case FreshnessBand.recent:
+        color = c.amber;
+        break;
+      case FreshnessBand.stale:
+        color = c.danger;
+        break;
+      case FreshnessBand.offline:
+        color = c.text3;
+        break;
+    }
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
       decoration: BoxDecoration(
-        color: context.gridColors.surface2,
+        color: color.withOpacity(0.14),
         borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: context.gridColors.hairline, width: 1),
+        border: Border.all(color: color.withOpacity(0.25), width: 1),
       ),
-      child: GridMono(label, size: 10, color: context.gridColors.text2, letterSpacing: 0.08),
+      child: GridMono(label, size: 10, color: color, letterSpacing: 0.08),
     );
   }
 }

--- a/test/utilities/time_ago_formatter_test.dart
+++ b/test/utilities/time_ago_formatter_test.dart
@@ -114,4 +114,39 @@ void main() {
       expect(color, Colors.red);
     });
   });
+
+  group('TimeAgoFormatter.bandFor', () {
+    test('null is offline', () {
+      expect(TimeAgoFormatter.bandFor(null), FreshnessBand.offline);
+    });
+
+    test('invalid string is offline', () {
+      expect(TimeAgoFormatter.bandFor('nope'), FreshnessBand.offline);
+    });
+
+    test('< 15m is fresh', () {
+      final ts = DateTime.now().subtract(const Duration(minutes: 5)).toIso8601String();
+      expect(TimeAgoFormatter.bandFor(ts), FreshnessBand.fresh);
+    });
+
+    test('15m-1h is recent', () {
+      final ts = DateTime.now().subtract(const Duration(minutes: 40)).toIso8601String();
+      expect(TimeAgoFormatter.bandFor(ts), FreshnessBand.recent);
+    });
+
+    test('1h-24h is stale', () {
+      final ts = DateTime.now().subtract(const Duration(hours: 5)).toIso8601String();
+      expect(TimeAgoFormatter.bandFor(ts), FreshnessBand.stale);
+    });
+
+    test('>= 24h is offline', () {
+      final ts = DateTime.now().subtract(const Duration(hours: 30)).toIso8601String();
+      expect(TimeAgoFormatter.bandFor(ts), FreshnessBand.offline);
+    });
+
+    test('future timestamp is offline', () {
+      final ts = DateTime.now().add(const Duration(hours: 1)).toIso8601String();
+      expect(TimeAgoFormatter.bandFor(ts), FreshnessBand.offline);
+    });
+  });
 }


### PR DESCRIPTION
## What changed

Two fixes for the contact profile view, where the battery pill was always grey and the last-seen time never colored:

- **Battery (root cause):** On Android, most location updates flow through the headless/background path (`onHeadlessLocation` -> `processBackgroundLocation` -> `_sendLocationUpdate`), which sent a legacy non-`gridv2` payload with no `battery` block. The receiver's `UserDeviceStatusCache` therefore only ever got `null` battery, so `_BatteryStatusPill` fell back to its grey "?" state. The foreground path already sent battery correctly. Fix: parse the native `batteryLevel` (0-100) / `isCharging` (and speed/heading) from the headless data map and emit a `gridv: 2` payload with the battery block. The existing pill banding (mint charging, danger <20%, amber <40%, otherwise normal) now lights up with real data.
- **Last-seen color:** The profile modal used a neutral `_MonoPill` (always `text2`/grey). Added a pure, unit-tested `TimeAgoFormatter.bandFor()` freshness classifier (fresh <15m / recent <1h / stale <24h / offline) and a `_FreshnessPill` that colors mint -> amber -> danger -> muted.

Added `bandFor` unit tests. `flutter analyze` on changed files: no new errors (only pre-existing `avoid_print`/`withOpacity` infos). `flutter test`: 478 passing.

**Known remaining limitation:** none — the previously battery-less background path now carries battery. If a sender is on an old pre-gridv2 build, or the OS genuinely can't read battery, the pill correctly shows the grey "?" placeholder.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Battery indicator and last-seen time now show their real status with color instead of always grey.
