### PR TITLE
fix(map): disengage auto-follow on touch so map can pan

### DIFF
--- a/changes/pr-293.md
+++ b/changes/pr-293.md
@@ -1,0 +1,1 @@
+[fix] You can now freely pan the map; panning stops auto-following your location.

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -1679,8 +1679,13 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
                   Listener(
                     behavior: HitTestBehavior.translucent,
                     onPointerDown: (_) {
-                      if (_followedContactId != null) {
-                        setState(() => _unlockContactFollow());
+                      // Touching the map disengages auto-follow so the camera
+                      // doesn't snap back mid-pan; locate button re-enables it.
+                      if (_followUser || _followedContactId != null) {
+                        setState(() {
+                          _followUser = false;
+                          _unlockContactFollow();
+                        });
                       }
                     },
                     child: ml.MapLibreMap(


### PR DESCRIPTION
## What changed

The map was effectively un-pannable when auto-follow was engaged: with `myLocationTrackingMode: MyLocationTrackingMode.tracking` active (set whenever `_followUser` is true, e.g. after tapping the "Center on me" locate button), native MapLibre continuously locks the camera onto the user puck, so any pan immediately snapped back. The existing `onCameraTrackingDismissed` disengage fired only after native had already dismissed tracking, while the per-frame `setState` in the camera listener kept re-pushing `tracking` to the platform view mid-gesture, fighting the user's drag.

The fix proactively disengages follow at the Flutter gesture layer: the `Listener.onPointerDown` wrapping the `MapLibreMap` now clears `_followUser` (and contact-follow) on touch, before the pan begins, so tracking mode is released and the camera no longer snaps back. Zoom and rotate are unaffected. The locate button still re-enables follow.

Scope: only map gesture/camera/follow-mode/tracking logic was touched; the sharing pill was not modified.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
You can now freely pan the map; panning stops auto-following your location.
