### PR TITLE
feat: animate sharing pill on each location broadcast

### DIFF
--- a/changes/pr-295.md
+++ b/changes/pr-295.md
@@ -1,0 +1,1 @@
+[feature] The sharing pill now animates each time your location is broadcast to your people.

--- a/lib/services/location/location_dispatch.dart
+++ b/lib/services/location/location_dispatch.dart
@@ -71,6 +71,25 @@ class LocationDispatch {
 
   bool _started = false;
 
+  // Fires once per successful post to rooms. UI (the sharing pill) listens
+  // to animate a "just broadcast" cue. Never emits while sharing is paused.
+  final _broadcastController = StreamController<void>.broadcast();
+
+  /// Broadcast tick — one event per successful location post to rooms.
+  Stream<void> get onBroadcast => _broadcastController.stream;
+
+  /// Mirrors [SharingStateNotifier.isPaused] for callers that only hold a
+  /// dispatch reference (e.g. the sharing pill cue).
+  bool get isPaused => _sharingState.isPaused;
+
+  /// Called by [RoomService] after a successful post. Suppressed while
+  /// paused/incognito so the cue never fires when we aren't really sharing.
+  void notifyBroadcast() {
+    if (_sharingState.isPaused) return;
+    if (_broadcastController.isClosed) return;
+    _broadcastController.add(null);
+  }
+
   Future<void> start() async {
     if (_started) return;
     _started = true;
@@ -95,6 +114,10 @@ class LocationDispatch {
     await _activitySub?.cancel();
     _activitySub = null;
     _started = false;
+  }
+
+  void dispose() {
+    _broadcastController.close();
   }
 
   SharingMode get mode => _mode;

--- a/lib/services/room_service.dart
+++ b/lib/services/room_service.dart
@@ -715,11 +715,11 @@ class RoomService {
     }
   }
 
-  void sendLocationEvent(String roomId, LocationUpdate location) async {
+  Future<bool> sendLocationEvent(String roomId, LocationUpdate location) async {
     final room = client.getRoomById(roomId);
     if (room == null || room.membership != Membership.join) {
       print("Skipping location update for room $roomId - no longer a member");
-      return;
+      return false;
     }
     if (room != null) {
       final latitude = location.latitude;
@@ -729,7 +729,7 @@ class RoomService {
       // Filter out low-accuracy locations to save battery and improve quality
       if (accuracy > 100) {
         print("⚠️  Skipping low-accuracy location for $roomId: ${accuracy.toStringAsFixed(1)}m error (threshold: 100m)");
-        return;
+        return false;
       }
 
       // Distance-based duplicate prevention
@@ -744,7 +744,7 @@ class RoomService {
 
         if (distance < 10) {
           print("⚠️  Skipping - only moved ${distance.toStringAsFixed(1)}m (threshold: 10m)");
-          return;
+          return false;
         }
         print("📍 Moved ${distance.toStringAsFixed(1)}m since last update");
       }
@@ -756,7 +756,7 @@ class RoomService {
         // Check if the message is already sent (legacy check)
         if (_recentlySentMessages[roomId]?.contains(messageHash) == true) {
           print("Duplicate location event skipped for room $roomId");
-          return;
+          return false;
         }
 
         // Build the event content. `gridv: 2` flags the additive payload:
@@ -814,6 +814,7 @@ class RoomService {
             // Also save to legacy global history (can be deprecated later)
             await locationHistoryRepository.addLocationPoint(myUserId, latitude, longitude);
           }
+          return true;
         } catch (e) {
           print("✗ Failed to send location event: $e");
 
@@ -836,8 +837,10 @@ class RoomService {
               'timestamp': DateTime.now(),
             });
           }
+          return false;
         }
     }
+    return false;
   }
 
   Future<int> getRoomMemberCount(String roomId) async {
@@ -960,13 +963,18 @@ class RoomService {
       print("📤 Sending location to ${roomsToUpdate.length} rooms in parallel...");
       final startTime = DateTime.now();
 
-      await Future.wait(
-        roomsToUpdate.map((roomId) => Future(() => sendLocationEvent(roomId, location))),
+      final results = await Future.wait(
+        roomsToUpdate.map((roomId) => sendLocationEvent(roomId, location)),
         eagerError: false, // Continue even if some sends fail
       );
 
       final elapsed = DateTime.now().difference(startTime).inMilliseconds;
       print("✓ Batch update complete in ${elapsed}ms");
+
+      // Pulse the sharing pill when at least one room actually received it.
+      if (results.any((sent) => sent)) {
+        locationDispatch?.notifyBroadcast();
+      }
     } else {
       print("No rooms to update");
     }
@@ -1018,7 +1026,7 @@ class RoomService {
           .toList();
 
       if (joinedMembers.length >= 2) {  // Valid room with at least 2 members
-        sendLocationEvent(roomId, currentLocation!);
+        await sendLocationEvent(roomId, currentLocation!);
       }
     }
   }

--- a/lib/widgets/sharing_recipient_pill.dart
+++ b/lib/widgets/sharing_recipient_pill.dart
@@ -10,6 +10,7 @@ import 'package:grid_frontend/blocs/groups/groups_state.dart';
 import 'package:grid_frontend/models/contact_display.dart';
 import 'package:grid_frontend/models/room.dart';
 import 'package:grid_frontend/repositories/sharing_preferences_repository.dart';
+import 'package:grid_frontend/services/location/location_dispatch.dart';
 import 'package:grid_frontend/services/sharing_state_notifier.dart';
 import 'package:grid_frontend/services/user_service.dart';
 import 'package:grid_frontend/styles/grid_colors.dart';
@@ -19,6 +20,12 @@ import 'package:grid_frontend/widgets/grid/grid_mono.dart';
 /// local user's location. Reactive to: per-target sharing prefs changes,
 /// contacts/groups bloc emissions, the paused state, and time-of-day window
 /// transitions (re-checked every 30s when any target has scheduled windows).
+///
+/// On each successful broadcast (via [LocationDispatch.onBroadcast]) it plays
+/// a quick two-stage cue: a mint stroke sweeps clockwise around the pill
+/// border ("sending"), then the status dot pulses ("sent"). Re-triggers
+/// inside the animation window are ignored so rapid posts don't strobe, and
+/// it never plays while sharing is paused/incognito.
 class SharingRecipientPill extends StatefulWidget {
   const SharingRecipientPill({super.key});
 
@@ -26,7 +33,8 @@ class SharingRecipientPill extends StatefulWidget {
   State<SharingRecipientPill> createState() => _SharingRecipientPillState();
 }
 
-class _SharingRecipientPillState extends State<SharingRecipientPill> {
+class _SharingRecipientPillState extends State<SharingRecipientPill>
+    with SingleTickerProviderStateMixin {
   int _count = 0;
   bool _hasScheduledWindows = false;
   Timer? _windowTicker;
@@ -38,6 +46,33 @@ class _SharingRecipientPillState extends State<SharingRecipientPill> {
   GroupsBloc? _groupsBloc;
   StreamSubscription<ContactsState>? _contactsSub;
   StreamSubscription<GroupsState>? _groupsSub;
+
+  // Broadcast cue. One controller drives both stages: the first ~65% sweeps
+  // the border stroke, the tail pulses the dot.
+  static const Duration _cueDuration = Duration(milliseconds: 700);
+  static const double _sweepEnd = 0.62; // sweep finishes, then dot pulses
+  late final AnimationController _cue;
+  late final Animation<double> _sweep; // 0→1 border draw
+  late final Animation<double> _pulse; // 0→1→0 dot emphasis
+  LocationDispatch? _dispatch;
+  StreamSubscription<void>? _broadcastSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _cue = AnimationController(vsync: this, duration: _cueDuration);
+    _sweep = CurvedAnimation(
+      parent: _cue,
+      curve: const Interval(0.0, _sweepEnd, curve: Curves.easeInOut),
+    );
+    _pulse = TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 0.0, end: 1.0), weight: 45),
+      TweenSequenceItem(tween: Tween(begin: 1.0, end: 0.0), weight: 55),
+    ]).animate(CurvedAnimation(
+      parent: _cue,
+      curve: const Interval(_sweepEnd, 1.0, curve: Curves.easeOut),
+    ));
+  }
 
   @override
   void didChangeDependencies() {
@@ -65,6 +100,13 @@ class _SharingRecipientPillState extends State<SharingRecipientPill> {
       _groupsSub = groups.stream.listen((_) => _recompute());
     }
 
+    final dispatch = context.read<LocationDispatch>();
+    if (dispatch != _dispatch) {
+      _broadcastSub?.cancel();
+      _dispatch = dispatch;
+      _broadcastSub = dispatch.onBroadcast.listen((_) => _playCue());
+    }
+
     _recompute();
   }
 
@@ -73,8 +115,18 @@ class _SharingRecipientPillState extends State<SharingRecipientPill> {
     _prefsRepo?.removeListener(_recompute);
     _contactsSub?.cancel();
     _groupsSub?.cancel();
+    _broadcastSub?.cancel();
     _windowTicker?.cancel();
+    _cue.dispose();
     super.dispose();
+  }
+
+  // Throttled: ignore re-triggers while a cue is already running.
+  void _playCue() {
+    if (!mounted) return;
+    if (_dispatch != null && _dispatch!.isPaused) return; // guard incognito
+    if (_cue.isAnimating) return;
+    _cue.forward(from: 0.0);
   }
 
   void _ensureWindowTicker() {
@@ -153,57 +205,127 @@ class _SharingRecipientPillState extends State<SharingRecipientPill> {
         final paused = sharingState.isPaused;
         final dotColor = paused ? context.gridColors.paused : context.gridColors.mint;
         final textColor = paused ? context.gridColors.paused : context.gridColors.text;
+        final mint = context.gridColors.mint;
         final String label;
         if (paused) {
           label = 'SHARING PAUSED';
         } else {
           label = 'SHARING WITH $_count';
         }
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
-          decoration: BoxDecoration(
-            color: context.gridColors.surface.withOpacity(0.92),
-            borderRadius: BorderRadius.circular(999),
-            border: Border.all(color: context.gridColors.hairlineStrong),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withOpacity(0.4),
-                blurRadius: 18,
-                offset: const Offset(0, 6),
-              ),
-            ],
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                width: 8,
-                height: 8,
+        return AnimatedBuilder(
+          animation: _cue,
+          builder: (context, _) {
+            // Dot pulse only when not paused and the cue is running.
+            final pulse = paused ? 0.0 : _pulse.value;
+            final dotScale = 1.0 + 0.45 * pulse;
+            final foregroundPainter = (paused || _cue.value == 0.0)
+                ? null
+                : _BorderSweepPainter(
+                    progress: _sweep.value,
+                    color: mint,
+                  );
+            return CustomPaint(
+              foregroundPainter: foregroundPainter,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
                 decoration: BoxDecoration(
-                  color: dotColor,
-                  shape: BoxShape.circle,
-                  boxShadow: paused
-                      ? null
-                      : [
-                          BoxShadow(
-                            color: context.gridColors.mint.withOpacity(0.55),
-                            blurRadius: 6,
-                          ),
-                        ],
+                  color: context.gridColors.surface.withOpacity(0.92),
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(color: context.gridColors.hairlineStrong),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.4),
+                      blurRadius: 18,
+                      offset: const Offset(0, 6),
+                    ),
+                  ],
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Transform.scale(
+                      scale: dotScale,
+                      child: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          color: dotColor,
+                          shape: BoxShape.circle,
+                          boxShadow: paused
+                              ? null
+                              : [
+                                  BoxShadow(
+                                    color: context.gridColors.mint
+                                        .withOpacity(0.55 + 0.45 * pulse),
+                                    blurRadius: 6 + 6 * pulse,
+                                  ),
+                                ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 7),
+                    GridMono(
+                      label,
+                      color: textColor,
+                      size: 10.5,
+                      letterSpacing: 0.1,
+                      weight: FontWeight.w600,
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(width: 7),
-              GridMono(
-                label,
-                color: textColor,
-                size: 10.5,
-                letterSpacing: 0.1,
-                weight: FontWeight.w600,
-              ),
-            ],
-          ),
+            );
+          },
         );
       },
     );
   }
+}
+
+/// Draws a mint stroke that traces the pill's rounded-rect perimeter
+/// clockwise from the top-center, from 0 to [progress] of the way around.
+class _BorderSweepPainter extends CustomPainter {
+  _BorderSweepPainter({required this.progress, required this.color});
+
+  final double progress; // 0..1
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (progress <= 0) return;
+
+    final radius = size.height / 2; // pill / stadium shape
+    final rect = Offset.zero & size;
+    final rrect = RRect.fromRectAndRadius(rect, Radius.circular(radius));
+
+    final full = Path()..addRRect(rrect);
+    // Rotate the start point to top-center so the sweep reads as starting
+    // from where the eye lands and going clockwise.
+    final metrics = full.computeMetrics().toList();
+    if (metrics.isEmpty) return;
+    final metric = metrics.first;
+    final total = metric.length;
+    final start = total * 0.25; // addRRect starts mid-right; ~25% ≈ top-center
+
+    final swept = total * progress.clamp(0.0, 1.0);
+    final path = Path();
+    if (start + swept <= total) {
+      path.addPath(metric.extractPath(start, start + swept), Offset.zero);
+    } else {
+      path.addPath(metric.extractPath(start, total), Offset.zero);
+      path.addPath(metric.extractPath(0, (start + swept) - total), Offset.zero);
+    }
+
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round
+      ..isAntiAlias = true;
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_BorderSweepPainter old) =>
+      old.progress != progress || old.color != color;
 }

--- a/lib/widgets/sharing_recipient_pill.dart
+++ b/lib/widgets/sharing_recipient_pill.dart
@@ -60,7 +60,12 @@ class _SharingRecipientPillState extends State<SharingRecipientPill>
   @override
   void initState() {
     super.initState();
-    _cue = AnimationController(vsync: this, duration: _cueDuration);
+    _cue = AnimationController(vsync: this, duration: _cueDuration)
+      // Reset to idle when the cue finishes so the border doesn't stay drawn;
+      // the next broadcast replays from zero.
+      ..addStatusListener((s) {
+        if (s == AnimationStatus.completed) _cue.reset();
+      });
     _sweep = CurvedAnimation(
       parent: _cue,
       curve: const Interval(0.0, _sweepEnd, curve: Curves.easeInOut),


### PR DESCRIPTION
## What changed

The top-of-map "SHARING WITH N" pill now plays a quick, subtle cue each time your location is successfully broadcast to your rooms. A thin mint stroke sweeps clockwise around the pill's rounded-rect border ("sending"), then the status dot pulses ("sent") — ~700ms total.

How it works:
- **Signal source:** `LocationDispatch` (the post chokepoint) exposes a broadcast `Stream<void> get onBroadcast`. `RoomService.updateRooms` calls `locationDispatch.notifyBroadcast()` after a batch post when at least one room's `sendEvent` succeeds (`sendLocationEvent` now returns `Future<bool>`).
- **Incognito guard:** `notifyBroadcast()` is suppressed when `SharingStateNotifier.isPaused`, so the cue never fires while sharing is paused. The pill also re-checks paused state at play and build time.
- **Throttle:** re-triggers within the active animation window are ignored (`if (_cue.isAnimating) return`), so rapid posts don't strobe.
- **Animation:** a single `AnimationController` drives both stages via `Interval`s; a `CustomPainter` traces a partial sub-path of the pill's `RRect` perimeter (clockwise from top-center) using `PathMetric`. Controller and stream subscription are disposed; all `setState` paths are `mounted`-guarded.

Scope: confined to `sharing_recipient_pill.dart`, `location_dispatch.dart`, and the broadcast wiring in `room_service.dart`. No changes to the MapLibre gesture/camera/tracking config.

## Changelog

- [ ] `skip` — No user-facing changes
- [x] `feature` — New functionality
- [ ] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
The sharing pill now animates each time your location is broadcast to your people.