### PR TITLE
fix(keychain): recover from locked keychain on cold launch from background

### DIFF
--- a/lib/providers/user_location_provider.dart
+++ b/lib/providers/user_location_provider.dart
@@ -25,12 +25,22 @@ class UserLocationProvider with ChangeNotifier {
 
 
   Future<void> _initializeLocations() async {
-    final locations = await locationRepository.getAllLatestLocations(); // Use getAllLatestLocations instead
-    for (var location in locations) {
-      _userLocations[location.userId] = location;
+    // A locked keychain on a cold background launch makes the DB unreadable;
+    // degrade to empty/cached instead of throwing, and recover on resume.
+    try {
+      final locations = await locationRepository.getAllLatestLocations();
+      for (var location in locations) {
+        _userLocations[location.userId] = location;
+      }
+      notifyListeners();
+    } catch (e) {
+      print("UserLocationProvider: failed to load locations (will retry on resume): $e");
     }
-    notifyListeners();
   }
+
+  /// Re-read locations from the DB. Safe to call on resume / once the keychain
+  /// is readable again. Keeps existing cache on failure.
+  Future<void> reloadLocations() => _initializeLocations();
 
   // Modify getLastSeen to return the most recent timestamp
   String? getLastSeen(String userId) {

--- a/lib/repositories/location_repository.dart
+++ b/lib/repositories/location_repository.dart
@@ -9,6 +9,8 @@ class LocationRepository {
 
   LocationRepository(this._databaseService);
 
+  DatabaseService get databaseService => _databaseService;
+
   static Future<void> createTable(Database db) async {
     await db.execute('''
     CREATE TABLE UserLocations (

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -21,6 +22,16 @@ class EncryptionKeyMissingException implements Exception {
   String toString() => 'Encryption key not found in keychain.';
 }
 
+/// Thrown when the keychain is temporarily unreadable (device locked / not yet
+/// unlocked since reboot, -25308). Distinct from [EncryptionKeyMissingException]
+/// so callers retry later instead of triggering destructive recovery.
+class KeychainTemporarilyUnavailableException implements Exception {
+  final Object cause;
+  const KeychainTemporarilyUnavailableException(this.cause);
+  @override
+  String toString() => 'Keychain temporarily unavailable: $cause';
+}
+
 class DatabaseService {
   static Database? _database;
   final FlutterSecureStorage _secureStorage;
@@ -36,6 +47,16 @@ class DatabaseService {
   // In-memory cache so a transient keychain error doesn't poison every
   // subsequent repo read in this process.
   String? _cachedKey;
+
+  /// True if [e] is the iOS "keychain locked / interaction not allowed" error
+  /// (-25308). The code may be the string '-25308' OR the literal SecurityError
+  /// name, with -25308 only in message/details — match all forms.
+  static bool isKeychainLocked(Object e) {
+    if (e is! PlatformException) return false;
+    if (e.code == '-25308') return true;
+    final blob = '${e.code} ${e.message ?? ''} ${e.details ?? ''}'.toLowerCase();
+    return blob.contains('-25308') || blob.contains('interaction is not allowed');
+  }
 
   /// Get the database instance (Singleton)
   Future<Database> get database async {
@@ -94,7 +115,16 @@ class DatabaseService {
   /// Fetch the encryption key
   Future<String> getEncryptionKey() async {
     if (_cachedKey != null) return _cachedKey!;
-    final key = await _readKeyWithFallback();
+    String? key;
+    try {
+      key = await _readKeyWithFallback();
+    } catch (e) {
+      // A locked keychain is retryable, NOT "key missing".
+      if (isKeychainLocked(e)) {
+        throw KeychainTemporarilyUnavailableException(e);
+      }
+      rethrow;
+    }
     if (key == null) {
       throw const EncryptionKeyMissingException();
     }
@@ -111,6 +141,25 @@ class DatabaseService {
     if (key == null) return false;
     _cachedKey = key;
     return true;
+  }
+
+  /// True if the key is currently cached in memory (already readable).
+  bool get hasCachedKey => _cachedKey != null;
+
+  /// Attempt to read + cache the key and complete any pending legacy migration.
+  /// Returns true if the key is now available. Call on resume / first unlock.
+  /// Never throws — a still-locked keychain just returns false.
+  Future<bool> tryRecoverEncryptionKey() async {
+    if (_cachedKey != null) return true;
+    try {
+      final key = await _readKeyWithFallback();
+      if (key == null) return false;
+      _cachedKey = key;
+      return true;
+    } catch (e) {
+      print('Encryption key recovery read failed (will retry later): $e');
+      return false;
+    }
   }
 
   /// Recovery for the worst case: keychain item is genuinely gone (data
@@ -157,10 +206,23 @@ class DatabaseService {
     // because the next read still finds the legacy item.
     try {
       await _secureStorage.write(key: 'encryptionKey', value: legacy);
+    } catch (e) {
+      // -25299 ("item already exists") means the key is already under the new
+      // accessibility; the legacy delete below must still run so the legacy
+      // item stops throwing -25308 on locked launches.
+      final alreadyExists = e is PlatformException &&
+          ('${e.code} ${e.message ?? ''} ${e.details ?? ''}').contains('-25299');
+      if (!alreadyExists) {
+        print('Encryption key migration write failed (non-fatal): $e');
+        return legacy;
+      }
+      print('Encryption key already in new accessibility; completing migration.');
+    }
+    try {
       await _legacyStorage.delete(key: 'encryptionKey');
       print('Migrated encryption key from legacy accessibility.');
     } catch (e) {
-      print('Encryption key migration write failed (non-fatal): $e');
+      print('Legacy encryption key delete failed (non-fatal): $e');
     }
     return legacy;
   }

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/services.dart';
 import 'package:grid_frontend/repositories/location_repository.dart';
+import 'package:grid_frontend/services/database_service.dart';
 import 'package:matrix/matrix.dart';
 import 'package:grid_frontend/services/message_processor.dart';
 import 'package:grid_frontend/services/room_service.dart';
@@ -423,10 +423,9 @@ class SyncManager with ChangeNotifier {
   void handleAppLifecycleState(bool isActive) {
     _isActive = isActive;
     if (isActive) {
-      if (_pendingMessages.isNotEmpty) {
-        _processPendingMessages();
-      }
-      mapBloc.add(MapLoadUserLocations());
+      // Device may now be unlocked — re-read the key, complete any pending
+      // legacy migration, then reprocess queued events and reload locations.
+      unawaited(_recoverKeychainThenRefresh());
 
       final pausedAt = _pausedTime;
       final bgGap =
@@ -448,6 +447,27 @@ class SyncManager with ChangeNotifier {
     } else {
       _pausedTime = DateTime.now();
     }
+  }
+
+  /// On resume the device is usually unlocked again: re-read + cache the DB
+  /// key (completing the legacy migration), then reprocess queued events and
+  /// reload locations so anything dropped while locked is recovered.
+  Future<void> _recoverKeychainThenRefresh() async {
+    final db = locationRepository.databaseService;
+    if (!db.hasCachedKey) {
+      final recovered = await db.tryRecoverEncryptionKey();
+      if (!recovered) {
+        // Still locked — leave pending queue intact for a later resume.
+        print('[SyncManager] Keychain still locked on resume; deferring refresh');
+        return;
+      }
+      // Key just became readable — reload locations that failed at launch.
+      await userLocationProvider.reloadLocations();
+    }
+    if (_pendingMessages.isNotEmpty) {
+      await _processPendingMessages();
+    }
+    mapBloc.add(MapLoadUserLocations());
   }
 
   /// Force a fresh sync stream when the long-poll socket is likely dead after
@@ -952,8 +972,11 @@ class SyncManager with ChangeNotifier {
           notifyListeners();
         }
       } catch (e) {
-        if (e is PlatformException && e.code == '-25308') {
-          // Queue message if we get keychain access error
+        if (e is KeychainTemporarilyUnavailableException ||
+            DatabaseService.isKeychainLocked(e)) {
+          // Keychain locked (cold launch on a locked device) — queue for
+          // retry instead of dropping the location.
+          print('[Sync] Keychain locked, queuing event ${event.eventId} for retry');
           _pendingMessages.add(PendingMessage(
             roomId: roomId,
             eventId: event.eventId ?? '',
@@ -984,7 +1007,13 @@ class SyncManager with ChangeNotifier {
           notifyListeners();
         }
       }).catchError((e) {
-        print("Error processing pending event ${pendingMessage.eventId}: $e");
+        if (e is KeychainTemporarilyUnavailableException ||
+            DatabaseService.isKeychainLocked(e)) {
+          // Still locked — re-queue so we don't lose it on the next resume.
+          _pendingMessages.add(pendingMessage);
+        } else {
+          print("Error processing pending event ${pendingMessage.eventId}: $e");
+        }
       });
     }
   }
@@ -1932,6 +1961,12 @@ class SyncManager with ChangeNotifier {
       
       print("[SyncManager] Orphaned location cleanup complete");
     } catch (e) {
+      if (e is KeychainTemporarilyUnavailableException ||
+          DatabaseService.isKeychainLocked(e)) {
+        // Keychain locked — skip destructive cleanup, retry when unlocked.
+        print("[SyncManager] Skipping orphaned cleanup: keychain locked");
+        return;
+      }
       print("[SyncManager] Error during manual location cleanup: $e");
     }
   }

--- a/test/services/database_service_keychain_test.dart
+++ b/test/services/database_service_keychain_test.dart
@@ -91,6 +91,74 @@ void main() {
     });
   });
 
+  group('isKeychainLocked', () {
+    test('matches code == -25308', () {
+      expect(
+        DatabaseService.isKeychainLocked(
+            PlatformException(code: '-25308', message: 'whatever')),
+        isTrue,
+      );
+    });
+
+    test('matches -25308 hidden in message/details', () {
+      expect(
+        DatabaseService.isKeychainLocked(PlatformException(
+          code: 'Unexpected security result code',
+          message: 'Code: -25308',
+        )),
+        isTrue,
+      );
+      expect(
+        DatabaseService.isKeychainLocked(PlatformException(
+          code: 'Unexpected security result code',
+          message: 'OSStatus',
+          details: 'value: -25308',
+        )),
+        isTrue,
+      );
+    });
+
+    test('matches "interaction is not allowed" text', () {
+      expect(
+        DatabaseService.isKeychainLocked(PlatformException(
+          code: 'Unexpected security result code',
+          message: 'User interaction is not allowed.',
+        )),
+        isTrue,
+      );
+    });
+
+    test('does not match unrelated errors', () {
+      expect(
+        DatabaseService.isKeychainLocked(
+            PlatformException(code: '-25300', message: 'item not found')),
+        isFalse,
+      );
+      expect(DatabaseService.isKeychainLocked(Exception('boom')), isFalse);
+    });
+  });
+
+  group('migration completion', () {
+    test('-25299 on migration write still deletes the legacy item', () async {
+      when(() => primary.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => null);
+      when(() => legacy.read(key: 'encryptionKey'))
+          .thenAnswer((_) async => 'legacy-key');
+      // "already exists" — key is already under the new accessibility.
+      when(() => primary.write(key: 'encryptionKey', value: 'legacy-key'))
+          .thenThrow(PlatformException(
+        code: 'Unexpected security result code',
+        message: 'The specified item already exists. -25299',
+      ));
+      when(() => legacy.delete(key: 'encryptionKey'))
+          .thenAnswer((_) async {});
+
+      expect(await service.hasEncryptionKey(), isTrue);
+      // Legacy item MUST be deleted so it stops throwing -25308 when locked.
+      verify(() => legacy.delete(key: 'encryptionKey')).called(1);
+    });
+  });
+
   group('getEncryptionKey', () {
     test('throws EncryptionKeyMissingException on clean absence', () async {
       when(() => primary.read(key: 'encryptionKey'))
@@ -104,13 +172,19 @@ void main() {
       );
     });
 
-    test('rethrows keychain errors so -25308 queueing still works', () async {
+    test('throws retryable KeychainTemporarilyUnavailableException when locked',
+        () async {
       when(() => primary.read(key: 'encryptionKey'))
           .thenThrow(lockedKeychain());
       when(() => legacy.read(key: 'encryptionKey'))
           .thenThrow(lockedKeychain());
 
-      expect(service.getEncryptionKey(), throwsA(isA<PlatformException>()));
+      // A locked keychain is retryable, NOT "key missing" — callers must be
+      // able to distinguish it so they don't wipe / drop data.
+      expect(
+        service.getEncryptionKey(),
+        throwsA(isA<KeychainTemporarilyUnavailableException>()),
+      );
     });
 
     test('caches the key after first successful read', () async {


### PR DESCRIPTION
## What changed

On a cold launch from background while the device is locked (or not yet unlocked since reboot), the DB encryption-key keychain read throws `-25308` ("User interaction is not allowed"). After #279 correctly made the keychain read rethrow, that rethrow cascaded at runtime: location loading crashed (empty map), incoming overnight locations were dropped, the legacy keychain migration never completed, and nothing recovered for the rest of the session.

This fix makes the runtime path degrade gracefully and recover once the device is unlocked:

- **`DatabaseService.isKeychainLocked(Object e)`** — robust matcher for `-25308` whether it is in `code`, `message`, or `details`, or appears as "interaction is not allowed". Replaces the broken `e.code == '-25308'` check (the real `PlatformException.code` is `"Unexpected security result code"`).
- **`getEncryptionKey`** keeps the in-memory cache and, on a locked read with no cache, throws a new retryable **`KeychainTemporarilyUnavailableException`** instead of `EncryptionKeyMissingException`, so callers distinguish "locked, retry later" from "genuinely gone".
- **Migration completion** — when the migration write fails with `-25299` ("item already exists"), the key is already under the new accessibility, so we now still delete the legacy `WhenUnlocked` item that was the source of the recurring `-25308`.
- **Queue, don't drop** — SyncManager queues keychain-locked events into the existing `_pendingMessages` mechanism and re-queues them if they fail again, instead of dropping into the "Error processing event" branch.
- **Graceful call sites** — `UserLocationProvider._initializeLocations` and the orphaned-location cleanup no longer throw uncaught on a locked keychain; they keep cached/empty state and defer.
- **Recover on resume** — `SyncManager.handleAppLifecycleState(true)` (the existing resume + cold-launch plumbing in `MapTab`) now re-reads + caches the key, completes the legacy migration, reprocesses queued pending messages, and reloads `UserLocationProvider` locations once the keychain is readable again.

The boot health-check (`hasEncryptionKey` / `main.dart`) is unchanged and still rethrows the raw keychain error, so a transient `-25308` at boot is still treated as "unknown, don't wipe" — #279 behavior preserved. Only a clean null-from-both-stores reaches destructive recovery.

Tests: extended `test/services/database_service_keychain_test.dart` with `isKeychainLocked` cases, the migration-completion-on-`-25299` case, and the transient-vs-missing distinction in `getEncryptionKey`. Full suite green (484 passing).

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed the app losing contacts' locations when opened in the morning after being backgrounded overnight.
