### PR TITLE
fix(location): mode-aware stationary heartbeat for Live mode

### DIFF
--- a/lib/services/location/location_dispatch.dart
+++ b/lib/services/location/location_dispatch.dart
@@ -260,11 +260,28 @@ class LocationDispatch {
                 heartbeat: Duration(minutes: 10),
               );
       case LocationActivity.still:
-        return const _Thresholds(
-          distanceM: 999999, // effectively never on distance alone
-          interval: Duration(minutes: 30),
-          heartbeat: Duration(minutes: 15),
-        );
+        // Stationary heartbeat is mode-aware: Live keeps contacts fresh even
+        // when not moving (the point of live sharing); Light sips battery.
+        switch (mode) {
+          case SharingMode.live:
+            return const _Thresholds(
+              distanceM: 999999,
+              interval: Duration(minutes: 5),
+              heartbeat: Duration(seconds: 45),
+            );
+          case SharingMode.balanced:
+            return const _Thresholds(
+              distanceM: 999999,
+              interval: Duration(minutes: 10),
+              heartbeat: Duration(minutes: 5),
+            );
+          case SharingMode.light:
+            return const _Thresholds(
+              distanceM: 999999, // effectively never on distance alone
+              interval: Duration(minutes: 30),
+              heartbeat: Duration(minutes: 15),
+            );
+        }
       case LocationActivity.unknown:
         // Before the activity classifier has weighed in. Be conservative —
         // every 60s or 100m. This is the bootup state.


### PR DESCRIPTION
## What changed

A stationary device's location-post cadence ignored the sharing mode: `_thresholdsFor`'s `LocationActivity.still` case returned a single 15-minute heartbeat regardless of Live/Balanced/Light. So a phone sitting still in **Live** mode only re-broadcast every 15 minutes — same as Light — which reads as "live isn't updating" (especially on an emulator/stationary device).

Now mode-aware when still:
- **Live:** 45s heartbeat (keeps contacts fresh even when not moving — the point of live sharing)
- **Balanced:** 5 min
- **Light:** 15 min (unchanged)

Distance threshold stays "never on distance alone" in all cases; only the time-based heartbeat changes.

**Known follow-up (separate repo):** the dispatch heartbeat can only fire as often as the `libre_location` plugin delivers a fix. When stationary, the plugin's own heartbeat (high preset = 300s) gates delivery, so Live-stationary will post about every ~5 min until the plugin's live heartbeat interval is also shortened (libre_location 0.4.x). This change removes the dispatch-side 15-min cap and the mode-blind behavior.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Live sharing now keeps your location fresh for contacts even when you're not moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)