### PR TITLE
fix(location): stop all location activity when sharing is toggled off

### DIFF
--- a/changes/pr-299.md
+++ b/changes/pr-299.md
@@ -1,0 +1,1 @@
+[fix] Turning off location sharing now fully stops location use, so the iOS location indicator no longer stays on.

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -286,12 +286,18 @@ class _SettingsPageState extends State<SettingsPage> {
   Future<void> _toggleIncognitoMode(bool value) async {
     final locationManager = Provider.of<LocationManager>(context, listen: false);
     final sharingState = context.read<SharingStateNotifier>();
+    final homeGeofence = context.read<HomeGeofenceService>();
 
     setState(() {
       _incognitoMode = value;
     });
 
     await sharingState.setUserIncognito(value);
+
+    // Re-sync the home geofence: removed while sharing is off (region
+    // monitoring otherwise keeps the OS location indicator on), restored
+    // when sharing resumes.
+    await homeGeofence.syncFromPrefs();
 
     if (value) {
       locationManager.stopTracking();

--- a/lib/services/location/home_geofence_service.dart
+++ b/lib/services/location/home_geofence_service.dart
@@ -61,6 +61,13 @@ class HomeGeofenceService {
   /// the same id and we explicitly remove first to refresh radius
   /// changes cleanly.
   Future<void> syncFromPrefs() async {
+    // When sharing is fully off, monitor nothing — a live geofence keeps the
+    // OS location indicator lit even with tracking stopped.
+    if (_sharingState.userIncognito) {
+      await _unregister();
+      return;
+    }
+
     final prefs = await SharedPreferences.getInstance();
     final enabled = prefs.getBool('auto_pause_at_home_enabled') ?? false;
     final raw = prefs.getString('home_location');


### PR DESCRIPTION
## What changed

Toggling **Sharing location** off in Settings called `LocationManager.stopTracking()`, but `HomeGeofenceService` independently keeps a `grid_home` geofence registered (for auto-pause-at-home). On iOS a monitored `CLCircularRegion` is active location use, so the OS location indicator (the status-bar/Dynamic-Island pill) stayed lit even though continuous GPS had stopped — i.e. location wasn't fully shutting off.

Fix:
- `HomeGeofenceService.syncFromPrefs()` now unregisters the geofence (and refuses to arm it) whenever `SharingStateNotifier.userIncognito` is set, so nothing is monitored while sharing is off — including across app relaunch.
- `_toggleIncognitoMode` re-syncs the geofence after flipping the toggle: removed when sharing goes off, restored (if auto-pause-at-home is enabled) when sharing comes back on.

`_startLocationTracking` already gates on `userIncognito`, so tracking doesn't restart on launch while off; this closes the remaining region-monitoring path.

Note: if the indicator ever persists with auto-pause-at-home **disabled**, that would point at the `libre_location` plugin's own stop path rather than the geofence — not seen here, but flagged for follow-up.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Turning off location sharing now fully stops location use, so the iOS location indicator no longer stays on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)