### PR TITLE
fix(invites): repair add-friend, group create/add-member, and pending display

### DIFF
--- a/changes/pr-300.md
+++ b/changes/pr-300.md
@@ -1,0 +1,1 @@
+[fix] Fixed adding friends and creating/managing groups — invites now reliably show as pending and no longer vanish or show as expired.

--- a/lib/repositories/user_repository.dart
+++ b/lib/repositories/user_repository.dart
@@ -59,6 +59,10 @@ class UserRepository {
       whereArgs: [userId, roomId],
     );
 
+    // Persist membershipStatus for direct rooms too (default 'invite') so a
+    // just-sent outgoing invite survives reload and shows as "Invite pending".
+    final status = membershipStatus ?? 'invite';
+
     if (existing.isEmpty) {
       // Insert new relationship
       await db.insert(
@@ -67,7 +71,7 @@ class UserRepository {
           'userId': userId,
           'roomId': roomId,
           'isDirect': isDirect ? 1 : 0,
-          'membershipStatus': isDirect ? null : (membershipStatus ?? 'invite'),
+          'membershipStatus': status,
         },
       );
     } else {
@@ -76,7 +80,7 @@ class UserRepository {
         'UserRelationships',
         {
           'isDirect': isDirect ? 1 : 0,
-          'membershipStatus': isDirect ? null : (membershipStatus ?? 'invite'),
+          'membershipStatus': status,
         },
         where: 'userId = ? AND roomId = ?',
         whereArgs: [userId, roomId],

--- a/lib/services/room_service.dart
+++ b/lib/services/room_service.dart
@@ -767,6 +767,15 @@ class RoomService {
     return utils.isCustomHomeserver(homeserver);
   }
 
+  /// Normalize a username to a full Matrix ID, matching createGroup's logic.
+  /// Custom homeserver: caller passes "user:domain"; default: bare local part.
+  String normalizeToMatrixId(String user) {
+    if (user.startsWith('@')) return user;
+    if (isCustomHomeserver()) return '@$user';
+    final homeserver = getMyHomeserver().replaceFirst('https://', '');
+    return '@$user:$homeserver';
+  }
+
   void getAndUpdateDisplayName() async {
 
     final prefs = await SharedPreferences.getInstance();

--- a/lib/services/sync_manager.dart
+++ b/lib/services/sync_manager.dart
@@ -1133,11 +1133,23 @@ class SyncManager with ChangeNotifier {
       final membershipStatus = event.content['membership'] as String? ?? 'invite';
 
       if (event.stateKey != null) {
-        await userRepository.updateMembershipStatus(
+        // Upsert the relationship — updateMembershipStatus is UPDATE-only, so a
+        // freshly-invited member (no row yet) was silently dropped, leaving the
+        // group showing 0 members. insertUserRelationship creates or updates.
+        await userRepository.insertUserRelationship(
             event.stateKey!,
             roomId,
-            membershipStatus
+            false, // group
+            membershipStatus: membershipStatus,
         );
+
+        // Ensure the invited member is in the room's member list so the group
+        // view lists them as pending immediately (not just on next full sync).
+        if (!room.members.contains(event.stateKey!)) {
+          await roomRepository.updateRoom(
+            room.copyWith(members: [...room.members, event.stateKey!]),
+          );
+        }
 
         groupsBloc.add(UpdateGroup(roomId));
 
@@ -1181,8 +1193,9 @@ class SyncManager with ChangeNotifier {
             event.stateKey!,
             roomId,
             true, // isDirect
+            membershipStatus: 'invite',
           );
-          
+
           print("SyncManager: Direct contact invite processed, refreshing contacts");
           contactsBloc.add(RefreshContacts());
           
@@ -1303,11 +1316,13 @@ class SyncManager with ChangeNotifier {
           );
           await userRepository.insertUser(gridUser);
 
-          // Update relationship
+          // Update relationship — this is the join handler, so mark joined
+          // (repo now defaults to 'invite', which would be wrong here).
           await userRepository.insertUserRelationship(
             event.stateKey!,
             roomId,
             !room.isGroup, // isDirect
+            membershipStatus: 'join',
           );
 
           // Update UI based on room type
@@ -1541,16 +1556,16 @@ class SyncManager with ChangeNotifier {
 
         await userRepository.insertUser(gridUser);
 
-        String? membershipStatus;
-        if (!isDirect) {
-          membershipStatus = await roomService.getUserRoomMembership(room.id, participantId) ?? 'invite';
-        }
+        // Compute real membership for direct rooms too — the repo now defaults
+        // to 'invite', so a joined contact must be written as 'join' here.
+        final membershipStatus =
+            await roomService.getUserRoomMembership(room.id, participantId) ?? 'invite';
 
         await userRepository.insertUserRelationship(
             participantId,
             room.id,
             isDirect,
-            membershipStatus: !isDirect ? membershipStatus : null
+            membershipStatus: membershipStatus,
         );
 
         // Also insert into RoomParticipants table for proper tracking

--- a/lib/utilities/utils.dart
+++ b/lib/utilities/utils.dart
@@ -99,6 +99,13 @@ int extractExpirationTimestamp(String roomName) {
   return 0;
 }
 
+/// Whether a group invite/room with [expiration] (epoch seconds) is expired.
+/// `<= 0` means "never expires" (groups encode 0; legacy used -1) and is
+/// NEVER expired. Otherwise expired once [expiration] is at/before now.
+bool isInviteExpired(int expiration, int nowEpochSeconds) {
+  return expiration > 0 && expiration <= nowEpochSeconds;
+}
+
 String formatUserId(String userId) {
   // Default homeserver fallback in case dotenv fails
   const FALLBACK_DEFAULT_HOMESERVER = 'matrix.mygrid.app';

--- a/lib/widgets/add_friend_modal.dart
+++ b/lib/widgets/add_friend_modal.dart
@@ -534,6 +534,16 @@ class _AddFriendModalState extends State<AddFriendModal>
         final syncManager = Provider.of<SyncManager>(context, listen: false);
         await syncManager.handleNewGroupCreation(roomId);
 
+        // Seed each invited member immediately so the new group lists them as
+        // pending right away, instead of showing 0 members until sync arrives.
+        // handleNewMemberInvited needs full Matrix IDs.
+        for (final member in normalizedMembers) {
+          await widget.groupsBloc.handleNewMemberInvited(
+            roomId,
+            widget.roomService.normalizeToMatrixId(member),
+          );
+        }
+
         widget.onGroupCreated?.call();
         widget.groupsBloc.add(RefreshGroups());
 

--- a/lib/widgets/invites_modal.dart
+++ b/lib/widgets/invites_modal.dart
@@ -221,7 +221,7 @@ Widget _buildInvitesList({
       if (parts.length > 3) {
         expiration = int.tryParse(parts[2]) ?? -1;
       }
-      if (expiration != -1 && expiration <= nowEpoch) {
+      if (isInviteExpired(expiration, nowEpoch)) {
         expiredGroupInvites.add(invite);
       } else {
         groupInvites.add(invite);
@@ -555,9 +555,7 @@ class _InvitesModalState extends State<InvitesModal> {
         if (parts.length > 3) {
           expiration = int.tryParse(parts[2]) ?? -1;
         }
-        // expiration of -1 means "permanent"; anything else that's already
-        // <= now is dead and belongs in the EXPIRED bucket.
-        if (expiration != -1 && expiration <= nowEpoch) {
+        if (isInviteExpired(expiration, nowEpoch)) {
           expiredGroupInvites.add(invite);
         } else {
           groupInvites.add(invite);
@@ -866,7 +864,7 @@ class _GroupInviteCard extends StatelessWidget {
               ),
               const SizedBox(width: 6),
               GridMono(
-                expiration == -1 ? 'permanent invite' : 'auto-ends in $expiry',
+                expiration <= 0 ? 'permanent invite' : 'auto-ends in $expiry',
                 uppercase: false,
                 size: 11,
                 letterSpacing: 0.04,
@@ -902,7 +900,8 @@ class _GroupInviteCard extends StatelessWidget {
   }
 
   static String _formatExpiry(int expiration) {
-    if (expiration == -1) return 'permanent';
+    if (expiration <= 0) return 'permanent'; // 0 = never (groups), -1 = legacy
+
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final diff = expiration - now;
     if (diff <= 0) return 'expired';

--- a/test/repositories/user_repository_test.dart
+++ b/test/repositories/user_repository_test.dart
@@ -203,7 +203,8 @@ void main() {
       // Act
       await repository.insertUserRelationship('user1', 'room1', true);
 
-      // Assert
+      // Assert: direct invites now persist 'invite' (was null) so an outgoing
+      // invite survives reload and shows as "Invite pending".
       verify(() => mockDatabase.query(
         'UserRelationships',
         where: 'userId = ? AND roomId = ?',
@@ -215,7 +216,7 @@ void main() {
           'userId': 'user1',
           'roomId': 'room1',
           'isDirect': 1,
-          'membershipStatus': null,
+          'membershipStatus': 'invite',
         },
       )).called(1);
     });
@@ -279,7 +280,7 @@ void main() {
           'userId': 'user1',
           'roomId': 'directRoom',
           'isDirect': 1,
-          'membershipStatus': null,
+          'membershipStatus': 'invite',
         },
       )).called(1);
     });

--- a/test/utilities/utils_test.dart
+++ b/test/utilities/utils_test.dart
@@ -277,4 +277,23 @@ void main() {
       expect(color3, isA<Color>());
     });
   });
+
+  group('isInviteExpired', () {
+    const now = 1000000;
+    test('0 (group never-expires) is never expired', () {
+      expect(isInviteExpired(0, now), isFalse);
+    });
+    test('-1 (legacy permanent) is never expired', () {
+      expect(isInviteExpired(-1, now), isFalse);
+    });
+    test('past timestamp is expired', () {
+      expect(isInviteExpired(now - 1, now), isTrue);
+    });
+    test('future timestamp is not expired', () {
+      expect(isInviteExpired(now + 1, now), isFalse);
+    });
+    test('exactly now is expired', () {
+      expect(isInviteExpired(now, now), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## What changed

Root-caused and fixed the core social-flow bugs:

1. **Every group invite showed 'expired'** (no Join/deny, couldn't re-invite): groups encode `0` = never-expire but invites_modal only treated `-1` as permanent, so `0` bucketed as expired. Added pure `isInviteExpired()` (`<=0` = never) used at all sites.
2. **Add friend → invite vanished from People**: `insertUserRelationship` forced `null` status for direct rooms so outgoing invites weren't persisted. Now persists `'invite'`; join paths pass `'join'`.
3. **Create group → 0 members**: `_processMemberStateEvent` used UPDATE-only (no row for new invitee) and didn't add to `Room.members`. Now upserts + adds to members; `_createGroup` seeds invited members into GroupsBloc immediately.
4. **Add member to existing group**: same sync path fixed.

Invited members now show as **'Invite pending'** in People and group views everywhere.

## Tests
489 passed (added isInviteExpired + direct-invite persistence). No new analyzer errors.

## Changelog

- [ ] `skip` — No user-facing changes
- [ ] `feature` — New functionality
- [x] `fix` — Bug fix
- [ ] `improvement` — Enhancement

**Release note:**
Fixed adding friends and creating/managing groups — invites now reliably show as pending and no longer vanish or show as expired.