### PR TITLE
fix(location): accept geo: URIs with RFC 5870 params / query suffix

### DIFF
--- a/lib/utilities/message_parser.dart
+++ b/lib/utilities/message_parser.dart
@@ -75,10 +75,21 @@ class MessageParser {
   }
 
   List<double>? _parseGeoUri(String geoUri) {
-    final parts = geoUri.substring(4).split(',');
+    // Strip anything after the coordinate list so cross-client senders don't
+    // get dropped: RFC 5870 allows a `;`-delimited param list (e.g. `;u=35`
+    // uncertainty, `;crs=...`) and some clients (iOS Maps share sheet) append
+    // a `?q=` query. Without this, `double.tryParse` fails on the trailing
+    // token and the whole fix is discarded — the contact never appears.
+    var coords = geoUri.substring(4);
+    final semi = coords.indexOf(';');
+    if (semi != -1) coords = coords.substring(0, semi);
+    final query = coords.indexOf('?');
+    if (query != -1) coords = coords.substring(0, query);
+
+    final parts = coords.split(',');
     if (parts.length < 2) return null;
-    final lat = double.tryParse(parts[0]);
-    final lng = double.tryParse(parts[1]);
+    final lat = double.tryParse(parts[0].trim());
+    final lng = double.tryParse(parts[1].trim());
     if (lat == null || lng == null) return null;
     return [lat, lng];
   }

--- a/test/utilities/message_parser_test.dart
+++ b/test/utilities/message_parser_test.dart
@@ -130,5 +130,55 @@ void main() {
       });
       expect(result, isNull);
     });
+
+    test('parses geo_uri with RFC 5870 uncertainty param (;u=)', () {
+      // iOS Maps / several Matrix clients append `;u=<meters>`. The longitude
+      // token must not swallow the param or the whole fix gets dropped.
+      final result = parser.parseLocationMessage({
+        'content': {
+          'msgtype': 'm.location',
+          'geo_uri': 'geo:40.7128,-74.0060;u=35',
+        },
+      });
+      expect(result, isNotNull);
+      expect(result!.latitude, 40.7128);
+      expect(result.longitude, closeTo(-74.0060, 0.0001));
+    });
+
+    test('parses geo_uri with altitude and uncertainty param', () {
+      final result = parser.parseLocationMessage({
+        'content': {
+          'msgtype': 'm.location',
+          'geo_uri': 'geo:40.7128,-74.0060,100;u=35',
+        },
+      });
+      expect(result, isNotNull);
+      expect(result!.latitude, 40.7128);
+      expect(result.longitude, closeTo(-74.0060, 0.0001));
+    });
+
+    test('parses geo_uri with ?q= query suffix', () {
+      final result = parser.parseLocationMessage({
+        'content': {
+          'msgtype': 'm.location',
+          'geo_uri': 'geo:40.7128,-74.0060?q=40.7128,-74.0060',
+        },
+      });
+      expect(result, isNotNull);
+      expect(result!.latitude, 40.7128);
+      expect(result.longitude, closeTo(-74.0060, 0.0001));
+    });
+
+    test('parses geo_uri with surrounding whitespace', () {
+      final result = parser.parseLocationMessage({
+        'content': {
+          'msgtype': 'm.location',
+          'geo_uri': 'geo: 40.7128 , -74.0060 ',
+        },
+      });
+      expect(result, isNotNull);
+      expect(result!.latitude, 40.7128);
+      expect(result.longitude, closeTo(-74.0060, 0.0001));
+    });
   });
 }


### PR DESCRIPTION
## What

Inbound `m.location` events from cross-client senders (iOS Maps share sheet, several other Matrix clients) carry a `geo:` URI with a trailing RFC 5870 parameter list — e.g. `geo:40.71,-74.00;u=35` (uncertainty) — or a `?q=` query suffix. `MessageParser._parseGeoUri` split on `,` and ran `double.tryParse` over the raw longitude token, which still contained the `;u=` / `?q=` suffix. `tryParse` returned `null`, the parser discarded the **entire** fix, and that contact silently never appeared on the map.

Grid's own sender emits clean `geo:$lat,$lng` URIs, so this only bit cross-client sharing — which is exactly why "I can't see my friend" reports (mixed iOS+Android) were so hard to pin down.

## Fix

Strip the `;`-param list and `?`-query before splitting, and `.trim()` each coordinate. Purely additive to what already parsed; no behavior change for clean or altitude-bearing URIs.

## Tests

`flutter test` — full suite green (493 passing). Added 4 cases to `message_parser_test.dart`: `;u=` param, altitude + `;u=`, `?q=` suffix, surrounding whitespace.

## Risk

**Low.** Single pure function, no I/O, no state, no dependency changes. Inbound-only; can't affect what we send. Coordinates still pass the existing `isFiniteLatLng` chokepoint downstream.

## Scope note

This addresses one concrete, reproducible slice of the "can't see contacts" cluster (cross-client senders). It is **not** the megolm key-rotation "everyone offline after v2.0" issue (build 840) — that's tracked separately and needs an on-device repro.
