### PR TITLE
fix(e2ee): widen megolm key-recovery noise gate to 6h ('everyone offline')

### DIFF
--- a/lib/services/message_processor.dart
+++ b/lib/services/message_processor.dart
@@ -50,6 +50,22 @@ class MessageProcessor {
   /// Callback for when decryption fails
   DecryptionErrorCallback? _onDecryptionError;
 
+  /// How stale a failed-decryption event may be and still warrant an active
+  /// megolm key re-request. Prior-install events flood catch-up sync and can
+  /// never recover (Grid keeps no message history), so we do need an upper
+  /// bound — but a peer's *most recent* location is routinely tens of minutes
+  /// old, and a tight 10-minute gate stranded those sessions undecryptable,
+  /// surfacing as "everyone offline" after the v2 upgrade. 6h still filters
+  /// ancient spam while recovering recent-but-stale sessions.
+  static const Duration keyRecoveryMaxAge = Duration(hours: 6);
+
+  /// Pure, testable gate: should we actively try to recover the megolm key
+  /// for a decrypt failure whose event was sent at [eventTs]? [now] is
+  /// injectable so this can be exercised without a Client. Future-dated
+  /// events (clock skew) are treated as recent, as before.
+  static bool shouldAttemptKeyRecovery(DateTime eventTs, DateTime now) =>
+      now.difference(eventTs) <= keyRecoveryMaxAge;
+
   // Per-session cooldown for explicit megolm key re-requests.
   final Map<String, DateTime> _keyRequestedAt = {};
   static const Duration _keyRequestCooldown = Duration(minutes: 5);
@@ -142,9 +158,10 @@ class MessageProcessor {
     if (decryptedEvent.type == 'm.room.encrypted' &&
         decryptedEvent.content['msgtype'] == 'm.bad.encrypted') {
       // Noise gate: old events from prior installs flood catch-up sync and can
-      // never recover (Grid keeps no history). Only act on recent failures.
-      final age = DateTime.now().difference(finalEvent.originServerTs);
-      if (age > const Duration(minutes: 10)) {
+      // never recover (Grid keeps no history). Bound recovery to recent-enough
+      // events, but not so tight that a peer's last (stale) location is
+      // stranded — see [shouldAttemptKeyRecovery].
+      if (!shouldAttemptKeyRecovery(finalEvent.originServerTs, DateTime.now())) {
         return null;
       }
       print('[MessageProcessor] ⚠️ DECRYPTION FAILED for event from ${finalEvent.senderId}');

--- a/test/services/message_processor_key_recovery_test.dart
+++ b/test/services/message_processor_key_recovery_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/services/message_processor.dart';
+
+/// Unit coverage for the megolm decrypt-failure noise gate. This is the
+/// gate that decides whether a failed-decryption event is recent enough
+/// to warrant an active key re-request. A previously too-tight 10-minute
+/// bound stranded peers whose most-recent location was tens of minutes
+/// old, surfacing as "everyone offline" after the v2 upgrade.
+void main() {
+  group('MessageProcessor.shouldAttemptKeyRecovery', () {
+    final now = DateTime.utc(2026, 7, 13, 12, 0, 0);
+
+    test('recovers a very recent failure', () {
+      expect(
+        MessageProcessor.shouldAttemptKeyRecovery(
+            now.subtract(const Duration(seconds: 30)), now),
+        isTrue,
+      );
+    });
+
+    test('recovers a stale-but-recent last location (regression case)', () {
+      // 45 minutes old: previously dropped by the 10-minute gate, which is
+      // exactly the "everyone offline" bug. Must now recover.
+      expect(
+        MessageProcessor.shouldAttemptKeyRecovery(
+            now.subtract(const Duration(minutes: 45)), now),
+        isTrue,
+      );
+    });
+
+    test('recovers right up to the boundary', () {
+      expect(
+        MessageProcessor.shouldAttemptKeyRecovery(
+            now.subtract(MessageProcessor.keyRecoveryMaxAge), now),
+        isTrue,
+      );
+    });
+
+    test('drops ancient prior-install spam', () {
+      expect(
+        MessageProcessor.shouldAttemptKeyRecovery(
+            now.subtract(const Duration(hours: 6, minutes: 1)), now),
+        isFalse,
+      );
+      expect(
+        MessageProcessor.shouldAttemptKeyRecovery(
+            now.subtract(const Duration(days: 3)), now),
+        isFalse,
+      );
+    });
+
+    test('treats future-dated (clock-skew) events as recent', () {
+      expect(
+        MessageProcessor.shouldAttemptKeyRecovery(
+            now.add(const Duration(minutes: 5)), now),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Top fire (#1 cluster, 7 independent reporters). After the v2 upgrade, users report **'everyone offline' / can't see contacts**, still present on build 840.

## Root cause
On megolm decrypt failure, `MessageProcessor.processEvent` only issues an active key re-request when the failed event is **< 10 minutes old**. Grid's own `onRoomKeyRequest`/`ShareKeysWith.all` forwarding is in place, but nothing *asks* unless the gate passes.

A peer's **most-recent** location is routinely tens of minutes old (background throttling, phone asleep). During catch-up sync after the v2 upgrade, that last-known event fails to decrypt but is already > 10 min old → no key request is ever sent → the session stays permanently undecryptable → the contact renders offline forever. Exactly the reported symptom.

## Fix
- Extract the gate into a **pure, injectable** `shouldAttemptKeyRecovery(eventTs, now)`.
- Widen the bound from 10 min to **6h**: still filters ancient prior-install catch-up spam (Grid keeps no history so those never recover), but recovers recent-but-stale sessions.
- Future-dated (clock-skew) events still treated as recent (unchanged).

## Tests
- New `test/services/message_processor_key_recovery_test.dart` (5 cases incl. the 45-min regression case).
- `flutter test` full suite green (494 pass).

## Risk
**Low.** Only widens *when* an already-existing, cooldown-throttled key request fires; no change to forwarding policy or crypto. Downside of the wider window is at most a few extra `m.room_key_request` to-device messages, still rate-limited by the existing 5-min per-session cooldown.

## Note
Widening the gate is necessary but may not be sufficient on its own — needs on-device confirmation from an affected S24/GrapheneOS reporter that stale sessions actually recover post-build. Recommend shipping to a test build and confirming with kaorukimura before wide release.