### PR TITLE
fix(location): reject exact (0,0) no-fix sentinel (hardening)

### DIFF
--- a/changes/pr-309.md
+++ b/changes/pr-309.md
@@ -1,0 +1,1 @@
+[improvement] Ignore location readings that never received a GPS fix.

--- a/lib/services/android_background_task.dart
+++ b/lib/services/android_background_task.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart' show MethodChannel;
 import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:matrix/matrix.dart';
 import 'package:grid_frontend/services/debug_log_service.dart';
+import 'package:grid_frontend/utilities/lat_lng_validation.dart';
 import 'package:grid_frontend/services/database_service.dart';
 import 'package:grid_frontend/services/backwards_compatibility_service.dart';
 import 'package:grid_frontend/repositories/location_repository.dart';
@@ -314,6 +315,14 @@ Future<void> _sendLocationUpdate(
   // Filter out low-accuracy locations to save battery and improve quality
   if (accuracy > 100) {
     print("Grid: ⚠️  Skipping low-accuracy location for ${room.name}: ${accuracy.toStringAsFixed(1)}m error");
+    return;
+  }
+
+  // Never broadcast a platform no-fix sentinel (exact-zero axis) — it strands
+  // the contact at Null Island (Indian Ocean) on every peer's map.
+  if (!isFiniteLatLng(latitude, longitude) ||
+      isNoFixSentinel(latitude, longitude)) {
+    print("Grid: ⚠️  Skipping no-fix/invalid location for ${room.name}: $latitude, $longitude");
     return;
   }
 

--- a/lib/services/room_service.dart
+++ b/lib/services/room_service.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:matrix/matrix.dart';
 import 'package:grid_frontend/utilities/utils.dart' as utils;
+import 'package:grid_frontend/utilities/lat_lng_validation.dart';
 import 'package:grid_frontend/services/user_service.dart';
 import 'package:matrix/matrix_api_lite/generated/model.dart' as matrix_model;
 import 'package:grid_frontend/repositories/user_repository.dart';
@@ -801,6 +802,14 @@ class RoomService {
       // Filter out low-accuracy locations to save battery and improve quality
       if (accuracy > 100) {
         print("⚠️  Skipping low-accuracy location for $roomId: ${accuracy.toStringAsFixed(1)}m error (threshold: 100m)");
+        return false;
+      }
+
+      // Never broadcast a platform no-fix sentinel (exact-zero axis) — it
+      // strands the contact at Null Island (Indian Ocean) on peers' maps.
+      if (!isFiniteLatLng(latitude, longitude) ||
+          isNoFixSentinel(latitude, longitude)) {
+        print("⚠️  Skipping no-fix/invalid location for $roomId: $latitude, $longitude");
         return false;
       }
 

--- a/lib/utilities/lat_lng_validation.dart
+++ b/lib/utilities/lat_lng_validation.dart
@@ -7,3 +7,16 @@ bool isFiniteLatLng(num lat, num lng) {
   if (lng is double && (lng.isNaN || lng.isInfinite)) return false;
   return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
 }
+
+/// True when a coordinate looks like a platform "no-fix" sentinel rather than
+/// a real GPS reading. Android's `getLastKnownLocation` (heartbeat / last-known
+/// paths) can hand back a partially-populated fix where one axis is left at an
+/// exact `0.0`. A genuine sub-degree GPS fix is never exactly `0.0` on an axis,
+/// so an exact zero on *either* latitude or longitude means "unset". Left
+/// through, a real longitude with a zeroed latitude (e.g. a user in India at
+/// `0.0, 77.x`) renders the contact stranded in the Indian Ocean.
+///
+/// Deliberately an exact `== 0.0` test: it only ever matches the sentinel, so
+/// there are no false positives to worry about (the equator / prime meridian
+/// to six decimals is open ocean, not a place any user is reporting from).
+bool isNoFixSentinel(num lat, num lng) => lat == 0.0 || lng == 0.0;

--- a/lib/utilities/lat_lng_validation.dart
+++ b/lib/utilities/lat_lng_validation.dart
@@ -8,15 +8,21 @@ bool isFiniteLatLng(num lat, num lng) {
   return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
 }
 
-/// True when a coordinate looks like a platform "no-fix" sentinel rather than
-/// a real GPS reading. Android's `getLastKnownLocation` (heartbeat / last-known
-/// paths) can hand back a partially-populated fix where one axis is left at an
-/// exact `0.0`. A genuine sub-degree GPS fix is never exactly `0.0` on an axis,
-/// so an exact zero on *either* latitude or longitude means "unset". Left
-/// through, a real longitude with a zeroed latitude (e.g. a user in India at
-/// `0.0, 77.x`) renders the contact stranded in the Indian Ocean.
+/// True for exact Null Island — `(0.0, 0.0)` on both axes.
 ///
-/// Deliberately an exact `== 0.0` test: it only ever matches the sentinel, so
-/// there are no false positives to worry about (the equator / prime meridian
-/// to six decimals is open ocean, not a place any user is reporting from).
-bool isNoFixSentinel(num lat, num lng) => lat == 0.0 || lng == 0.0;
+/// A zero-initialised location struct that never received a fix serialises as
+/// exactly `(0, 0)`, so this is the conventional "unset coordinate" check. It
+/// is defence in depth: nothing in Grid is known to emit it today, but a
+/// no-fix reading that slipped through would render a contact in the Gulf of
+/// Guinea and be re-broadcast to peers.
+///
+/// **Both** axes must be zero. An earlier revision of this guard rejected a
+/// zero on *either* axis, which would also discard genuine fixes on the
+/// equator or the prime meridian — real places, including populated parts of
+/// Ecuador, Kenya, Indonesia, Ghana and the UK. That trade was not worth
+/// making for a sentinel that is only ever emitted with both axes zeroed.
+///
+/// Note this deliberately does not chase pins that *drift as the map pans* —
+/// that symptom is a screen-space projection error, not a bad coordinate.
+/// See PR #316.
+bool isNoFixSentinel(num lat, num lng) => lat == 0.0 && lng == 0.0;

--- a/lib/utilities/message_parser.dart
+++ b/lib/utilities/message_parser.dart
@@ -43,6 +43,9 @@ class MessageParser {
       final coords = _parseGeoUri(geoUri);
       if (coords == null) return null;
       if (!isFiniteLatLng(coords[0], coords[1])) return null;
+      // Drop platform no-fix sentinels (exact-zero axis) so a stale/absent
+      // reading never strands the contact at Null Island (Indian Ocean).
+      if (isNoFixSentinel(coords[0], coords[1])) return null;
 
       // Extras live at the top level of the event content. Each is
       // independently optional; absence = "sender didn't tell us".

--- a/test/utilities/lat_lng_validation_test.dart
+++ b/test/utilities/lat_lng_validation_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/utilities/lat_lng_validation.dart';
+
+void main() {
+  group('isFiniteLatLng', () {
+    test('accepts a normal in-range fix', () {
+      expect(isFiniteLatLng(40.7128, -74.0060), isTrue);
+    });
+
+    test('rejects NaN / Infinity', () {
+      expect(isFiniteLatLng(double.nan, 0.0), isFalse);
+      expect(isFiniteLatLng(0.0, double.infinity), isFalse);
+    });
+
+    test('rejects out-of-range coordinates', () {
+      expect(isFiniteLatLng(91.0, 0.0), isFalse);
+      expect(isFiniteLatLng(0.0, 181.0), isFalse);
+    });
+  });
+
+  group('isNoFixSentinel', () {
+    test('flags exact Null Island', () {
+      expect(isNoFixSentinel(0.0, 0.0), isTrue);
+    });
+
+    test('flags a zeroed latitude axis (Indian Ocean pin signature)', () {
+      // Real Bengaluru longitude, latitude dropped to the no-fix sentinel.
+      expect(isNoFixSentinel(0.0, 77.5946), isTrue);
+    });
+
+    test('flags a zeroed longitude axis', () {
+      expect(isNoFixSentinel(51.5074, 0.0), isTrue);
+    });
+
+    test('does not flag a genuine sub-degree fix', () {
+      expect(isNoFixSentinel(0.0001, 0.0001), isFalse);
+      expect(isNoFixSentinel(-33.8688, 151.2093), isFalse);
+      expect(isNoFixSentinel(40.7128, -74.0060), isFalse);
+    });
+  });
+}

--- a/test/utilities/lat_lng_validation_test.dart
+++ b/test/utilities/lat_lng_validation_test.dart
@@ -23,16 +23,21 @@ void main() {
       expect(isNoFixSentinel(0.0, 0.0), isTrue);
     });
 
-    test('flags a zeroed latitude axis (Indian Ocean pin signature)', () {
-      // Real Bengaluru longitude, latitude dropped to the no-fix sentinel.
-      expect(isNoFixSentinel(0.0, 77.5946), isTrue);
+    test('does NOT flag a real fix on the equator', () {
+      // Quito sits within a hair of 0 latitude; Kenya, Indonesia and Ecuador
+      // are all populated equatorial places. A zeroed longitude alone is not
+      // evidence of a no-fix reading.
+      expect(isNoFixSentinel(0.0, 77.5946), isFalse);
+      expect(isNoFixSentinel(0.0, -78.4678), isFalse);
     });
 
-    test('flags a zeroed longitude axis', () {
-      expect(isNoFixSentinel(51.5074, 0.0), isTrue);
+    test('does NOT flag a real fix on the prime meridian', () {
+      // Greenwich, and everything else on 0 longitude from Ghana to the UK.
+      expect(isNoFixSentinel(51.5074, 0.0), isFalse);
+      expect(isNoFixSentinel(5.6037, 0.0), isFalse);
     });
 
-    test('does not flag a genuine sub-degree fix', () {
+    test('does not flag ordinary fixes', () {
       expect(isNoFixSentinel(0.0001, 0.0001), isFalse);
       expect(isNoFixSentinel(-33.8688, 151.2093), isFalse);
       expect(isNoFixSentinel(40.7128, -74.0060), isFalse);

--- a/test/utilities/message_parser_test.dart
+++ b/test/utilities/message_parser_test.dart
@@ -96,25 +96,32 @@ void main() {
       expect(result, isNull);
     });
 
-    test('returns null when latitude axis is a zeroed no-fix sentinel', () {
-      // Real longitude (India) with a dropped latitude => Indian Ocean pin.
+    test('keeps a genuine equatorial fix (zero latitude only)', () {
+      // Only exact (0,0) is a sentinel. A zero on one axis is a real place —
+      // this is a point in the Indian Ocean off India, but equally it could be
+      // Quito or Nairobi, and dropping it would hide a contact who is there.
       final result = parser.parseLocationMessage({
         'content': {
           'msgtype': 'm.location',
           'geo_uri': 'geo:0.0,77.5946',
         },
       });
-      expect(result, isNull);
+      expect(result, isNotNull);
+      expect(result!.latitude, 0.0);
+      expect(result.longitude, closeTo(77.5946, 0.0001));
     });
 
-    test('returns null when longitude axis is a zeroed no-fix sentinel', () {
+    test('keeps a genuine prime-meridian fix (zero longitude only)', () {
+      // Greenwich. Real place, real users.
       final result = parser.parseLocationMessage({
         'content': {
           'msgtype': 'm.location',
           'geo_uri': 'geo:51.5074,0.0',
         },
       });
-      expect(result, isNull);
+      expect(result, isNotNull);
+      expect(result!.latitude, closeTo(51.5074, 0.0001));
+      expect(result.longitude, 0.0);
     });
 
     test('handles geo_uri with altitude (third component)', () {

--- a/test/utilities/message_parser_test.dart
+++ b/test/utilities/message_parser_test.dart
@@ -86,16 +86,35 @@ void main() {
       expect(result.longitude, closeTo(-151.2093, 0.0001));
     });
 
-    test('parses zero coordinates', () {
+    test('returns null for Null Island no-fix sentinel (0.0, 0.0)', () {
       final result = parser.parseLocationMessage({
         'content': {
           'msgtype': 'm.location',
           'geo_uri': 'geo:0.0,0.0',
         },
       });
-      expect(result, isNotNull);
-      expect(result!.latitude, 0.0);
-      expect(result.longitude, 0.0);
+      expect(result, isNull);
+    });
+
+    test('returns null when latitude axis is a zeroed no-fix sentinel', () {
+      // Real longitude (India) with a dropped latitude => Indian Ocean pin.
+      final result = parser.parseLocationMessage({
+        'content': {
+          'msgtype': 'm.location',
+          'geo_uri': 'geo:0.0,77.5946',
+        },
+      });
+      expect(result, isNull);
+    });
+
+    test('returns null when longitude axis is a zeroed no-fix sentinel', () {
+      final result = parser.parseLocationMessage({
+        'content': {
+          'msgtype': 'm.location',
+          'geo_uri': 'geo:51.5074,0.0',
+        },
+      });
+      expect(result, isNull);
     });
 
     test('handles geo_uri with altitude (third component)', () {


### PR DESCRIPTION
## What this is

Defence in depth against an **unset coordinate** — exact Null Island, `(0.0, 0.0)` on both axes.

> **Re-scoped after review.** This PR was originally written up as the fix for the "contact pin in the Indian Ocean" report from @supermanisdum and @_mx_ace. [It is not](https://github.com/Rezivure/Grid-Mobile/pull/309#issuecomment-5469457581) — @EnbyAce correctly pointed out that the reported pin *moves as you pan the map*, which a bad coordinate cannot cause. That symptom is a screen-space projection error and its fix is **#316**. This PR is hardening only, and closes no issue.

## Changelog

- [ ] `feature`
- [ ] `fix`
- [x] `improvement`
- [ ] `skip`

**Release note:**
Ignore location readings that never received a GPS fix.

## Guard

`isNoFixSentinel(lat, lng)` returns true only when **both** axes are exactly `0.0`. A zero-initialised location struct that never received a fix serialises that way, so this is the conventional unset-coordinate check.

An earlier revision rejected a zero on *either* axis and claimed "zero false positives". That was wrong — it would also discard genuine fixes on the equator and the prime meridian (Ecuador, Kenya, Indonesia, Ghana, the UK). Requiring both axes is sufficient for the sentinel and costs nothing.

Applied at three chokepoints:
- **inbound** — `MessageParser.parseLocationMessage`, so a peer's no-fix never renders
- **outbound** — `room_service.dart` and `android_background_task.dart`, so we never broadcast our own

## Tests

Full suite green (498). Coverage asserts equatorial and prime-meridian fixes are **kept**, and only exact `(0,0)` is dropped.

## Risk

Low. Additive, exact-match on both axes, no behaviour change for any real fix.