### PR TITLE
fix(account): route passkey-only deletions away from SMS flow

### DIFF
--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -20,6 +20,7 @@ import 'dart:convert';
 import 'package:grid_frontend/providers/auth_provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:grid_frontend/utilities/utils.dart' as utils;
+import 'package:grid_frontend/utilities/account_deletion_route.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'dart:io';
@@ -2243,10 +2244,31 @@ class _SettingsPageState extends State<SettingsPage> {
     final sharedPreferences = await SharedPreferences.getInstance();
     final serverType = sharedPreferences.getString('serverType');
     final homeserver = await client.homeserver;
-    final defaultHomeserver = await dotenv.env['MATRIX_SERVER_URL'];
-    if (serverType == 'default' || (homeserver?.toString().trim() == defaultHomeserver?.trim())) {
-      _deactivateSMSAccount();
-      return;
+    final defaultHomeserver = dotenv.env['MATRIX_SERVER_URL'];
+    final route = resolveAccountDeletionRoute(
+      serverType: serverType,
+      homeserver: homeserver?.toString(),
+      defaultHomeserver: defaultHomeserver,
+      phoneNumber: sharedPreferences.getString('phone_number'),
+    );
+
+    switch (route) {
+      case AccountDeletionRoute.sms:
+        _deactivateSMSAccount();
+        return;
+      case AccountDeletionRoute.passkeyManualSupport:
+        // Passkey-only accounts have no phone number and GAUTH has no passkey
+        // self-deactivation endpoint yet — don't send them down the SMS path
+        // (which reports a misleading "Phone number not found" error).
+        InAppNotifier.instance.show(
+          title: 'Contact support to delete',
+          message: 'Passkey accounts can\'t be deleted in-app yet. '
+              'Please DM Chandler to have your account removed.',
+          variant: InAppNotificationVariant.warning,
+        );
+        return;
+      case AccountDeletionRoute.customServerPassword:
+        break;
     }
 
 

--- a/lib/utilities/account_deletion_route.dart
+++ b/lib/utilities/account_deletion_route.dart
@@ -1,0 +1,47 @@
+/// Which deletion flow an account should use.
+///
+/// Grid has three distinct deletion paths and the wrong one produces a
+/// misleading error. In particular, passkey-only accounts on the default
+/// server have no phone number on file, so routing them through the SMS
+/// deactivation flow surfaces "Phone number not found / beta account?" —
+/// confusing and wrong. Resolving the route up front keeps the picker in one
+/// pure, testable place.
+enum AccountDeletionRoute {
+  /// Default-server account created via SMS/phone — deactivate via the GAUTH
+  /// phone-code flow.
+  sms,
+
+  /// Self-hosted / custom homeserver — deactivate directly against the Matrix
+  /// deactivate endpoint with the account password.
+  customServerPassword,
+
+  /// Default-server passkey-only account — no phone number on file. GAUTH has
+  /// no passkey self-deactivation endpoint yet, so send the user to support
+  /// rather than down the SMS path.
+  passkeyManualSupport,
+}
+
+/// Decide how a delete-account request should be handled.
+///
+/// Mirrors the original inline check (`serverType == 'default'` OR the trimmed
+/// homeserver matching the default homeserver) for identifying a default-server
+/// account, then splits default-server accounts by whether a phone number is on
+/// file so passkey-only accounts no longer fall into the SMS flow.
+AccountDeletionRoute resolveAccountDeletionRoute({
+  required String? serverType,
+  required String? homeserver,
+  required String? defaultHomeserver,
+  required String? phoneNumber,
+}) {
+  final isDefaultServer = serverType == 'default' ||
+      (homeserver?.trim() == defaultHomeserver?.trim());
+
+  if (!isDefaultServer) {
+    return AccountDeletionRoute.customServerPassword;
+  }
+
+  final hasPhone = phoneNumber != null && phoneNumber.isNotEmpty;
+  return hasPhone
+      ? AccountDeletionRoute.sms
+      : AccountDeletionRoute.passkeyManualSupport;
+}

--- a/test/utilities/account_deletion_route_test.dart
+++ b/test/utilities/account_deletion_route_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/utilities/account_deletion_route.dart';
+
+void main() {
+  const defaultHs = 'https://matrix.mygrid.app';
+
+  group('resolveAccountDeletionRoute', () {
+    test('default serverType + phone number => SMS flow', () {
+      expect(
+        resolveAccountDeletionRoute(
+          serverType: 'default',
+          homeserver: defaultHs,
+          defaultHomeserver: defaultHs,
+          phoneNumber: '+15551234567',
+        ),
+        AccountDeletionRoute.sms,
+      );
+    });
+
+    test('default serverType + no phone => passkey manual support', () {
+      expect(
+        resolveAccountDeletionRoute(
+          serverType: 'default',
+          homeserver: defaultHs,
+          defaultHomeserver: defaultHs,
+          phoneNumber: null,
+        ),
+        AccountDeletionRoute.passkeyManualSupport,
+      );
+    });
+
+    test('default serverType + empty phone => passkey manual support', () {
+      expect(
+        resolveAccountDeletionRoute(
+          serverType: 'default',
+          homeserver: defaultHs,
+          defaultHomeserver: defaultHs,
+          phoneNumber: '',
+        ),
+        AccountDeletionRoute.passkeyManualSupport,
+      );
+    });
+
+    test('matching homeserver (serverType null) + no phone => passkey', () {
+      // Passkey-only account where serverType wasn't persisted but the
+      // homeserver still matches the default: must NOT fall into SMS.
+      expect(
+        resolveAccountDeletionRoute(
+          serverType: null,
+          homeserver: defaultHs,
+          defaultHomeserver: defaultHs,
+          phoneNumber: null,
+        ),
+        AccountDeletionRoute.passkeyManualSupport,
+      );
+    });
+
+    test('homeserver match tolerates surrounding whitespace', () {
+      expect(
+        resolveAccountDeletionRoute(
+          serverType: null,
+          homeserver: '  $defaultHs  ',
+          defaultHomeserver: defaultHs,
+          phoneNumber: '+15551234567',
+        ),
+        AccountDeletionRoute.sms,
+      );
+    });
+
+    test('custom homeserver => password deactivation flow', () {
+      expect(
+        resolveAccountDeletionRoute(
+          serverType: 'custom',
+          homeserver: 'https://matrix.example.org',
+          defaultHomeserver: defaultHs,
+          phoneNumber: null,
+        ),
+        AccountDeletionRoute.customServerPassword,
+      );
+    });
+
+    test('custom server ignores phone presence', () {
+      expect(
+        resolveAccountDeletionRoute(
+          serverType: 'custom',
+          homeserver: 'https://matrix.example.org',
+          defaultHomeserver: defaultHs,
+          phoneNumber: '+15551234567',
+        ),
+        AccountDeletionRoute.customServerPassword,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Passkey-only accounts on the default server have no phone number on file, but `_deleteAccount` routed **every** default-server account through `_deactivateSMSAccount`. That path reads `phone_number` from prefs and, finding none, showed the misleading **"Phone number not found / Is this a beta/test account?"** warning — reported by a passkey user (silently_drowning) trying to delete their account.

## Fix
Extract the routing decision into a pure, unit-tested helper `resolveAccountDeletionRoute` with three outcomes:
- `sms` — default server + phone on file (unchanged behavior)
- `customServerPassword` — self-hosted / custom homeserver (unchanged behavior)
- `passkeyManualSupport` — default server, no phone (passkey-only): show honest guidance to DM Chandler instead of the SMS error

No behavior change for SMS or custom-server accounts; only passkey-only accounts are re-routed.

## Tests
- New `test/utilities/account_deletion_route_test.dart` — 7 cases covering all branches incl. serverType-null + homeserver-match and whitespace tolerance.
- `flutter test` full suite green (496 pass, 7 pre-existing skips).
- `flutter analyze` on touched files: no new issues (pre-existing withOpacity/dead-code warnings only).

## Risk
**Low.** Client-side only, pure decision function, additive branch. Worst case a passkey user still can't self-delete (they get a clear support message instead of a confusing error).

## Follow-up (backend, PR-only)
GAUTH has no passkey self-deactivation endpoint. Adding one (`/deactivate` variant keyed on the passkey `user_id` / username rather than phone) would let these accounts self-serve. That touches Grid-Auth-Middleware which auto-deploys to prod — needs careful human review + a test path.