### PR TITLE
fix(location): drop invalid fixes at the dispatch throttle chokepoint

### DIFF
--- a/lib/services/location/location_dispatch.dart
+++ b/lib/services/location/location_dispatch.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:libre_location/libre_location.dart' as libre;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../utilities/lat_lng_validation.dart';
 import '../sharing_state_notifier.dart';
 import 'location_update.dart';
 
@@ -144,6 +145,14 @@ class LocationDispatch {
   /// for distance/interval bookkeeping when true.
   bool shouldPost(LocationUpdate fix) {
     if (_sharingState.isPaused) return false;
+
+    // Reject a NaN/Inf/out-of-range fix at the throttle chokepoint. Left
+    // through, an invalid fix gets recorded as `_lastPostedLocation`, and the
+    // next haversine distance against it is NaN — which never clears the
+    // distance threshold, silently wedging distance-based posting until a
+    // timed heartbeat bails us out. Dropping it here keeps the bookkeeping
+    // anchored to the last *real* position (complements the send-path guard).
+    if (!isFiniteLatLng(fix.latitude, fix.longitude)) return false;
 
     final now = DateTime.now();
     final last = _lastPostAt;

--- a/test/services/location_dispatch_test.dart
+++ b/test/services/location_dispatch_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:grid_frontend/services/location/location_dispatch.dart';
+import 'package:grid_frontend/services/location/location_update.dart';
+import 'package:grid_frontend/services/sharing_state_notifier.dart';
+
+/// Builds a plausible fix. Only lat/lng vary across these tests.
+LocationUpdate _fix(double lat, double lng) => LocationUpdate(
+      latitude: lat,
+      longitude: lng,
+      accuracy: 10.0,
+      speed: 0.0,
+      heading: 0.0,
+      altitude: 0.0,
+      timestamp: DateTime.now(),
+      isMoving: false,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LocationDispatch.shouldPost coordinate guard', () {
+    late LocationDispatch dispatch;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      dispatch = LocationDispatch(SharingStateNotifier());
+      await dispatch.start();
+    });
+
+    test('posts the first valid fix', () {
+      expect(dispatch.shouldPost(_fix(40.7128, -74.0060)), isTrue);
+    });
+
+    test('drops a NaN fix and never records it as the last position', () {
+      // First real fix establishes bookkeeping.
+      expect(dispatch.shouldPost(_fix(40.7128, -74.0060)), isTrue);
+
+      // A NaN fix must be rejected...
+      expect(dispatch.shouldPost(_fix(double.nan, double.nan)), isFalse);
+
+      // ...and must NOT have poisoned the bookkeeping: a nearby real fix a
+      // few meters away should still be throttled on distance (not forced
+      // through by a NaN haversine). Same coords ⇒ 0m ⇒ under threshold.
+      expect(dispatch.shouldPost(_fix(40.7128, -74.0060)), isFalse);
+    });
+
+    test('drops an Infinity fix', () {
+      expect(dispatch.shouldPost(_fix(double.infinity, 0.0)), isFalse);
+    });
+
+    test('drops out-of-range coordinates', () {
+      expect(dispatch.shouldPost(_fix(91.0, 0.0)), isFalse);
+      expect(dispatch.shouldPost(_fix(0.0, 181.0)), isFalse);
+    });
+
+    test('an invalid fix does not consume the first-fix slot', () {
+      // An invalid fix arriving first must not count as "the first fix";
+      // the next genuine fix should still post as the session opener.
+      expect(dispatch.shouldPost(_fix(double.nan, 0.0)), isFalse);
+      expect(dispatch.shouldPost(_fix(48.8566, 2.3522)), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What
`LocationDispatch.shouldPost()` — the single throttle chokepoint between the raw GPS stream and the Matrix post path — had **no coordinate validity guard**.

## Why it matters
When the plugin emits a NaN / Inf / out-of-range fix:
1. `shouldPost` returns `true` and records it as `_lastPostedLocation`.
2. The next *real* fix computes a haversine distance **against NaN** → NaN.
3. `NaN >= threshold` is always false, so distance-based posting silently wedges until a timed heartbeat bails it out.

This complements the send-path guards in #309 (which drop the invalid *post*) by stopping the poison one layer earlier, so the throttle bookkeeping stays anchored to the last real position.

## Change
- Guard the top of `shouldPost` with the existing `isFiniteLatLng` (already on main — no dependency on #309's `isNoFixSentinel`).
- Add the first-ever `LocationDispatch` unit coverage (5 tests): first-fix, NaN rejection + no-poison, Infinity, out-of-range, and 'invalid fix doesn't consume the first-fix slot'.

## Testing
- `flutter test` full suite green — **494 pass, 7 skip**.
- `flutter analyze` clean on touched files.

## Risk
**Low.** Additive guard on a pure decision method; no behavior change for valid fixes. Independent of #307/#308/#309/#310.