### PR TITLE
fix(map): compass rose rotates the wrong way (#304)

### DIFF
--- a/lib/screens/map/compass_geometry.dart
+++ b/lib/screens/map/compass_geometry.dart
@@ -1,0 +1,15 @@
+import 'dart:math' as math;
+
+/// Geometry helpers for the map's floating compass rose.
+///
+/// MapLibre reports the camera bearing in degrees measured clockwise from
+/// true north (rotating the map clockwise increases the bearing). The compass
+/// rose is a fixed graphic whose red arrow must keep pointing at true north on
+/// screen, so it has to counter-rotate against the camera bearing.
+///
+/// [Transform.rotate] treats a positive angle as a clockwise turn, therefore
+/// the rose must be rotated by the negated bearing. Rotating it by `+bearing`
+/// (the previous behaviour) spun the arrow the wrong way — see issue #304.
+double compassRoseAngleRadians(double bearingDegrees) {
+  return -bearingDegrees * (math.pi / 180.0);
+}

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:matrix/matrix.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:grid_frontend/screens/map/compass_geometry.dart';
 import 'package:grid_frontend/repositories/sharing_preferences_repository.dart';
 import 'package:grid_frontend/repositories/user_repository.dart';
 import 'package:grid_frontend/services/in_app_notifier.dart';
@@ -2584,7 +2585,7 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
             alignment: Alignment.center,
             children: [
               Transform.rotate(
-                angle: _currentMapRotation * (math.pi / 180),
+                angle: compassRoseAngleRadians(_currentMapRotation),
                 child: CustomPaint(
                   size: const Size(26, 26),
                   painter: CompassPainter(

--- a/test/screens/map/compass_geometry_test.dart
+++ b/test/screens/map/compass_geometry_test.dart
@@ -1,0 +1,30 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/screens/map/compass_geometry.dart';
+
+void main() {
+  group('compassRoseAngleRadians', () {
+    test('no bearing leaves the rose upright', () {
+      expect(compassRoseAngleRadians(0), 0.0);
+    });
+
+    test('counter-rotates against the camera bearing (issue #304)', () {
+      // MapLibre bearing is clockwise-from-north; the rose must turn the
+      // opposite way so its north arrow keeps pointing at true north.
+      expect(compassRoseAngleRadians(90), closeTo(-math.pi / 2, 1e-12));
+      expect(compassRoseAngleRadians(45), closeTo(-math.pi / 4, 1e-12));
+    });
+
+    test('is the negation of a naive same-direction rotation', () {
+      for (final deg in [0.0, 30.0, 123.4, 180.0, 270.0, 359.9]) {
+        final naive = deg * (math.pi / 180.0);
+        expect(compassRoseAngleRadians(deg), closeTo(-naive, 1e-12));
+      }
+    });
+
+    test('handles a full turn', () {
+      expect(compassRoseAngleRadians(360), closeTo(-2 * math.pi, 1e-12));
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Issue #304: the floating map compass indicator rotates in the **wrong direction** — its red north arrow points away from true north as the map is rotated. Reported on Android 17 (no GPlay) and iOS 26.3.1, v2.0.0 builds 833/834.

## Root cause
The compass rose was rotated by `+_currentMapRotation` (the camera bearing). MapLibre reports bearing as degrees **clockwise from north**, and Flutter's `Transform.rotate` treats a **positive** angle as a clockwise turn. Rotating the fixed rose the *same* way as the camera makes the arrow swing opposite to true north. It must **counter-rotate** (negated bearing).

## Fix
- New pure helper `compassRoseAngleRadians(bearingDegrees)` in `lib/screens/map/compass_geometry.dart` returning `-bearing` in radians, with the rationale documented.
- `map_tab.dart` uses the helper instead of the inline `+bearing` expression.
- 4 new unit tests (first coverage for this geometry).

## Testing
- `flutter test` full suite: **493 pass, 7 skip** (includes the 4 new tests).
- `flutter analyze` clean on touched files.

## Risk
Low. Single-line behavioural change to a purely visual overlay; no data/E2EE/location-path impact. Worth a quick on-device glance to confirm the arrow now tracks north (the duplicate/second working compass mentioned in #304 is a separate concern).