### PR TITLE
fix(map): collapse background list sheet when contact sheet opens (#305)

### DIFF
--- a/lib/services/contact_sheet_controller.dart
+++ b/lib/services/contact_sheet_controller.dart
@@ -18,6 +18,10 @@ class ContactSheetController extends ChangeNotifier {
   ContactDisplay? _contact;
   ContactDisplay? get contact => _contact;
 
+  /// Whether a contact profile sheet is currently presented. Used by the
+  /// background list sheet to collapse itself out of the way (#305).
+  bool get isOpen => _contact != null;
+
   void open(ContactDisplay contact) {
     _contact = contact;
     notifyListeners();

--- a/lib/utilities/sheet_coordination.dart
+++ b/lib/utilities/sheet_coordination.dart
@@ -1,0 +1,29 @@
+/// Pure geometry helpers for coordinating the two stacked bottom sheets
+/// on the map screen (#305 "double menu overlay obstructs map").
+///
+/// MapTab renders a persistent list sheet (contacts/groups) *and*, when a
+/// contact is tapped, an inline contact-profile sheet on top of it. If the
+/// list sheet is left expanded, the two menus stack and hide the map. When
+/// an overlay sheet is present we collapse the background list sheet down to
+/// its minimum so only one menu is showing over the map.
+library;
+
+/// Target extent the background list sheet should move to, or `null` when it
+/// should be left exactly where the user put it.
+///
+/// * [overlayOpen] — is the contact-profile sheet currently presented?
+/// * [minExtent] — the list sheet's `minChildSize`.
+/// * [currentExtent] — its current fractional extent.
+///
+/// Returns [minExtent] only when an overlay is open and the list sheet is
+/// still taller than its minimum; otherwise `null` (no movement needed).
+double? backgroundSheetTargetExtent({
+  required bool overlayOpen,
+  required double minExtent,
+  required double currentExtent,
+}) {
+  if (!overlayOpen) return null;
+  // Already at (or below) the collapsed handle — nothing to animate.
+  if (currentExtent <= minExtent) return null;
+  return minExtent;
+}

--- a/lib/widgets/map_scroll_window.dart
+++ b/lib/widgets/map_scroll_window.dart
@@ -20,6 +20,8 @@ import 'package:grid_frontend/blocs/groups/groups_state.dart';
 import 'package:grid_frontend/services/sync_manager.dart';
 import 'package:grid_frontend/blocs/invitations/invitations_event.dart';
 import 'package:grid_frontend/utilities/utils.dart';
+import 'package:grid_frontend/utilities/sheet_coordination.dart';
+import 'package:grid_frontend/services/contact_sheet_controller.dart';
 import 'contacts_subscreen.dart';
 import 'groups_subscreen.dart';
 import 'invites_modal.dart';
@@ -114,6 +116,11 @@ class _MapScrollWindowState extends State<MapScrollWindow>
 
     _groupsBloc.add(LoadGroups());
 
+    // #305: when a contact profile sheet opens on top of us, collapse this
+    // background list sheet to its minimum so the two menus don't stack and
+    // hide the map.
+    ContactSheetController.instance.addListener(_onContactSheetChanged);
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       Provider.of<SelectedSubscreenProvider>(context, listen: false)
           .setSelectedSubscreen('contacts');
@@ -142,9 +149,27 @@ class _MapScrollWindowState extends State<MapScrollWindow>
 
   @override
   void dispose() {
+    ContactSheetController.instance.removeListener(_onContactSheetChanged);
     _expandController.dispose();
     _fadeController.dispose();
     super.dispose();
+  }
+
+  // #305: collapse the background list sheet out of the way when a contact
+  // profile sheet is presented over it.
+  void _onContactSheetChanged() {
+    if (!mounted || !_scrollableController.isAttached) return;
+    final target = backgroundSheetTargetExtent(
+      overlayOpen: ContactSheetController.instance.isOpen,
+      minExtent: 0.3,
+      currentExtent: _scrollableController.size,
+    );
+    if (target == null) return;
+    _scrollableController.animateTo(
+      target,
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeInOut,
+    );
   }
 
   Future<List<GridRoom.Room>> _fetchGroupRooms() async {

--- a/test/utilities/sheet_coordination_test.dart
+++ b/test/utilities/sheet_coordination_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/utilities/sheet_coordination.dart';
+
+void main() {
+  group('backgroundSheetTargetExtent (#305 double-menu overlay)', () {
+    test('no overlay open -> never moves the list sheet', () {
+      expect(
+        backgroundSheetTargetExtent(
+          overlayOpen: false,
+          minExtent: 0.3,
+          currentExtent: 0.7,
+        ),
+        isNull,
+      );
+    });
+
+    test('overlay open + list sheet expanded -> collapse to minimum', () {
+      expect(
+        backgroundSheetTargetExtent(
+          overlayOpen: true,
+          minExtent: 0.3,
+          currentExtent: 0.7,
+        ),
+        0.3,
+      );
+    });
+
+    test('overlay open but list sheet already at minimum -> no movement', () {
+      expect(
+        backgroundSheetTargetExtent(
+          overlayOpen: true,
+          minExtent: 0.3,
+          currentExtent: 0.3,
+        ),
+        isNull,
+      );
+    });
+
+    test('overlay open but list sheet below minimum -> no movement', () {
+      expect(
+        backgroundSheetTargetExtent(
+          overlayOpen: true,
+          minExtent: 0.3,
+          currentExtent: 0.1,
+        ),
+        isNull,
+      );
+    });
+
+    test('overlay open + list sheet just above minimum -> collapse', () {
+      expect(
+        backgroundSheetTargetExtent(
+          overlayOpen: true,
+          minExtent: 0.3,
+          currentExtent: 0.31,
+        ),
+        0.3,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem (#305)
Opening a contact menu overlays it onto the persistent list sheet, stacking **two menus** that obstruct the map. Reported on Android 17 (no Google Play Services) and iOS 26.3.1 (builds 833/834).

## Root cause
`MapTab` renders `MapScrollWindow`'s persistent `DraggableScrollableSheet` (contacts/groups list, extent 0.3–0.7) *and* — when a contact/marker is tapped — an inline `ContactProfileModal` sheet in its own Stack on top (initial 0.5). Nothing collapsed the background list sheet, so both were visible at once.

## Fix
When `ContactSheetController` reports a profile sheet is open, `MapScrollWindow` animates its `DraggableScrollableController` down to `minChildSize` (0.3) so only one menu shows over the map. The list sheet is untouched when no overlay is present or when it's already collapsed.

- New pure helper `backgroundSheetTargetExtent()` (`lib/utilities/sheet_coordination.dart`) holds the movement decision so it's unit-testable in isolation.
- `ContactSheetController.isOpen` getter added for the coordination signal.
- Listener wired in `initState`/removed in `dispose`; guarded on `mounted` + `isAttached`.

## Tests
- 5 new unit tests in `test/utilities/sheet_coordination_test.dart`.
- `flutter test` full suite green (494 pass, 7 pre-existing skips).
- `dart analyze` on touched files: no new issues (only pre-existing `withOpacity`/`surfaceVariant` deprecation infos).

## Risk
**Low** — purely client-side UI sheet coordination; no data, e2ee, or network paths touched. Worth an on-device glance to confirm the collapse animation feels right on tap.