### PR TITLE
fix(auth): stop pointing passkey failures at nonexistent SMS option (#285)

### DIFF
--- a/lib/screens/onboarding/server_select_screen.dart
+++ b/lib/screens/onboarding/server_select_screen.dart
@@ -13,6 +13,7 @@ import 'package:grid_frontend/providers/auth_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:grid_frontend/services/in_app_notifier.dart';
 import 'package:grid_frontend/services/passkey_service.dart';
+import 'package:grid_frontend/utilities/passkey_error_guidance.dart';
 import 'package:grid_frontend/widgets/passkey_prompt_dialog.dart';
 import 'package:grid_frontend/widgets/turnstile_widget.dart';
 
@@ -892,7 +893,7 @@ class _ServerSelectScreenState extends State<ServerSelectScreen> with TickerProv
         (Route<dynamic> route) => false,
       );
     } catch (e) {
-      _showErrorDialog('Passkey login failed. Please try again or use SMS.');
+      _showErrorDialog(passkeyLoginErrorMessage());
     } finally {
       if (mounted) setState(() => _isPasskeyLoading = false);
     }
@@ -916,7 +917,7 @@ class _ServerSelectScreenState extends State<ServerSelectScreen> with TickerProv
         (Route<dynamic> route) => false,
       );
     } catch (e) {
-      _showErrorDialog('Passkey signup failed. Please try SMS verification.');
+      _showErrorDialog(passkeySignupErrorMessage());
     } finally {
       if (mounted) setState(() => _isPasskeyLoading = false);
     }

--- a/lib/utilities/passkey_error_guidance.dart
+++ b/lib/utilities/passkey_error_guidance.dart
@@ -1,0 +1,28 @@
+/// Honest, actionable user-facing guidance for passkey auth failures.
+///
+/// SMS verification was deprecated and there is no SMS fallback in the signup
+/// or login UI, so the old "Please try SMS verification" copy pointed users at
+/// an option that does not exist (GH #285). These helpers return messages that
+/// only reference paths a user can actually take: retry, use a different
+/// password manager / device authenticator, or reach a human.
+///
+/// Pure functions — no BuildContext, no I/O — so they are unit-testable.
+library;
+
+/// Where to send users who need hands-on help. Keeping this in one place means
+/// both messages stay consistent if it ever changes.
+const String _supportHint =
+    'If it keeps failing, open an issue at github.com/Rezivure/Grid-Mobile or reach out to the team.';
+
+/// Guidance shown when creating a brand-new account with a passkey fails.
+String passkeySignupErrorMessage() {
+  return 'We couldn\'t create your passkey. Make sure your device or password '
+      'manager supports passkeys, then try again. $_supportHint';
+}
+
+/// Guidance shown when signing in with an existing passkey fails.
+String passkeyLoginErrorMessage() {
+  return 'We couldn\'t sign you in with your passkey. Try again, and make sure '
+      'you\'re using the same device or password manager you signed up with. '
+      '$_supportHint';
+}

--- a/test/utilities/passkey_error_guidance_test.dart
+++ b/test/utilities/passkey_error_guidance_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/utilities/passkey_error_guidance.dart';
+
+void main() {
+  group('passkeySignupErrorMessage', () {
+    final msg = passkeySignupErrorMessage();
+
+    test('does not mention SMS (deprecated, no SMS option exists — GH #285)',
+        () {
+      expect(msg.toLowerCase(), isNot(contains('sms')));
+    });
+
+    test('points to passkey support requirement', () {
+      expect(msg.toLowerCase(), contains('passkey'));
+    });
+
+    test('offers an actionable next step (retry)', () {
+      expect(msg.toLowerCase(), contains('try again'));
+    });
+
+    test('offers a real escape hatch (github / team)', () {
+      final lower = msg.toLowerCase();
+      expect(lower.contains('github') || lower.contains('team'), isTrue);
+    });
+
+    test('is non-empty', () {
+      expect(msg.trim(), isNotEmpty);
+    });
+  });
+
+  group('passkeyLoginErrorMessage', () {
+    final msg = passkeyLoginErrorMessage();
+
+    test('does not mention SMS (deprecated — GH #285)', () {
+      expect(msg.toLowerCase(), isNot(contains('sms')));
+    });
+
+    test('mentions same device / password manager guidance', () {
+      final lower = msg.toLowerCase();
+      expect(lower.contains('device') || lower.contains('password manager'),
+          isTrue);
+    });
+
+    test('offers an actionable next step (retry)', () {
+      expect(msg.toLowerCase(), contains('try again'));
+    });
+
+    test('offers a real escape hatch (github / team)', () {
+      final lower = msg.toLowerCase();
+      expect(lower.contains('github') || lower.contains('team'), isTrue);
+    });
+
+    test('is non-empty', () {
+      expect(msg.trim(), isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Problem (GH #285)
When passkey signup or login fails, the error dialogs told users to "Please try SMS verification" / "use SMS" — but SMS auth is **deprecated** and there is **no SMS option** anywhere in the signup or login UI. Users hit a hard dead end: the only button is "OK", and the promised fallback doesn't exist.

## Fix
Replace both misleading strings with honest, actionable guidance produced by two pure helpers in `lib/utilities/passkey_error_guidance.dart`:
- `passkeySignupErrorMessage()` — check device/password-manager passkey support, retry, and a real escape hatch (open a GitHub issue / reach the team).
- `passkeyLoginErrorMessage()` — retry, use the same device/password manager you signed up with, same escape hatch.

No fabricated fallback paths. Copy references only actions a user can actually take.

## Testing
- 10 new unit tests (`test/utilities/passkey_error_guidance_test.dart`) asserting the messages never mention SMS and always offer a retry + real escape hatch.
- `flutter test` full suite green (499 pass).
- `flutter analyze` clean on all touched files.

## Risk
**Low** — client-side, user-facing copy only; no auth logic changed. Does not fix the underlying per-manager passkey failures (server/native, tracked separately), but removes a dead-end that made every failure look unrecoverable.

Closes #285