### PR TITLE
fix(map): correct Android marker drift from physical-pixel projection (#303, #301)

### DIFF
--- a/changes/pr-316.md
+++ b/changes/pr-316.md
@@ -1,0 +1,1 @@
+[fix] Fixed contact pins appearing in the wrong place and drifting as you move the map on Android.

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:matrix/matrix.dart';
@@ -18,6 +19,7 @@ import 'package:http/http.dart' as http;
 import 'package:google_fonts/google_fonts.dart';
 
 import 'grid_map_style.dart';
+import 'marker_projection.dart';
 import 'maplibre_camera_facade.dart';
 
 import 'package:grid_frontend/styles/tokens.dart';
@@ -1398,10 +1400,18 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
       final screenPoints = await controller.toScreenLocationBatch(mlPoints);
       // Ignore stale responses — camera may have moved past us.
       if (!mounted || seq != _projectionSeq) return;
+      // maplibre-native reports Android screen points in PHYSICAL pixels but
+      // Flutter's overlay Positioned() works in LOGICAL pixels, so on high-DPR
+      // devices markers drift at ~devicePixelRatio× the pan speed and only
+      // align at (0,0). Normalise to logical pixels. (#303, #301)
+      final divisor = markerProjectionDivisor(
+        defaultTargetPlatform,
+        MediaQuery.of(context).devicePixelRatio,
+      );
       for (var idx = 0; idx < keys.length && idx < screenPoints.length; idx++) {
         final p = screenPoints[idx];
         _markerScreenPositions[keys[idx]] =
-            Offset(p.x.toDouble(), p.y.toDouble());
+            logicalMarkerOffset(p.x.toDouble(), p.y.toDouble(), divisor);
       }
       setState(() {});
     } catch (_) {

--- a/lib/screens/map/marker_projection.dart
+++ b/lib/screens/map/marker_projection.dart
@@ -1,0 +1,39 @@
+import 'dart:ui' show Offset;
+
+import 'package:flutter/foundation.dart' show TargetPlatform;
+
+/// Helpers for normalising maplibre-native's projected screen coordinates
+/// into the logical-pixel space that Flutter's widget layer expects.
+///
+/// maplibre-native's Android `Projection.toScreenLocation` returns points in
+/// PHYSICAL device pixels, whereas Flutter's `Positioned`/`Offset` work in
+/// LOGICAL pixels. On high-DPR devices (e.g. an S24 Ultra at ~3x) this makes
+/// overlay markers drift across the screen at roughly devicePixelRatio× the
+/// map's pan speed and only line up with the map at the origin (0,0).
+/// iOS already returns logical points, so no correction is applied there.
+/// See Grid-Mobile issues #303 and #301.
+
+/// The divisor to apply to raw maplibre screen coordinates for [platform].
+///
+/// Android reports physical pixels, so divide by [devicePixelRatio]; every
+/// other platform already reports logical pixels, so divide by 1. A
+/// non-positive [devicePixelRatio] is treated as 1 to avoid corrupting the
+/// projection when the ratio is unavailable.
+double markerProjectionDivisor(
+  TargetPlatform platform,
+  double devicePixelRatio,
+) {
+  if (platform == TargetPlatform.android && devicePixelRatio > 0) {
+    return devicePixelRatio;
+  }
+  return 1.0;
+}
+
+/// Convert a raw projected screen point into logical pixels using [divisor].
+///
+/// A non-positive [divisor] is treated as 1 (identity) so a bad ratio can
+/// never blow up marker placement.
+Offset logicalMarkerOffset(double rawX, double rawY, double divisor) {
+  final d = divisor <= 0 ? 1.0 : divisor;
+  return Offset(rawX / d, rawY / d);
+}

--- a/lib/widgets/location_history_modal.dart
+++ b/lib/widgets/location_history_modal.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:maplibre_gl/maplibre_gl.dart' as ml;
@@ -20,6 +21,7 @@ import 'package:grid_frontend/widgets/grid/grid_mono.dart';
 import 'package:grid_frontend/widgets/grid/grid_sheet.dart';
 import 'package:matrix/matrix.dart';
 import 'package:grid_frontend/utilities/lat_lng_validation.dart';
+import 'package:grid_frontend/screens/map/marker_projection.dart';
 
 class LocationHistoryModal extends StatefulWidget {
   final String userId;  // For individual history, this is userId. For groups, this is roomId
@@ -638,11 +640,26 @@ class _LocationHistoryModalState extends State<LocationHistoryModal> {
     try {
       final screen = await controller.toScreenLocationBatch(pts);
       if (!mounted || seq != _projectionSeq) return;
+      // Same physical-vs-logical pixel correction as the live map: on Android
+      // maplibre-native reports these points in PHYSICAL pixels while the
+      // Positioned() overlay below works in LOGICAL ones, so history markers
+      // drift at ~devicePixelRatio× the pan speed without it. (#303, #301)
+      final divisor = markerProjectionDivisor(
+        defaultTargetPlatform,
+        MediaQuery.of(context).devicePixelRatio,
+      );
       _markerScreenPositions
         ..clear()
         ..addEntries([
           for (var i = 0; i < keys.length && i < screen.length; i++)
-            MapEntry(keys[i], Offset(screen[i].x.toDouble(), screen[i].y.toDouble())),
+            MapEntry(
+              keys[i],
+              logicalMarkerOffset(
+                screen[i].x.toDouble(),
+                screen[i].y.toDouble(),
+                divisor,
+              ),
+            ),
         ]);
       setState(() {});
     } catch (_) {}

--- a/test/screens/map/marker_projection_test.dart
+++ b/test/screens/map/marker_projection_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart' show TargetPlatform;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/screens/map/marker_projection.dart';
+
+void main() {
+  group('markerProjectionDivisor', () {
+    test('Android divides by devicePixelRatio (physical -> logical pixels)', () {
+      expect(markerProjectionDivisor(TargetPlatform.android, 3.0), 3.0);
+      expect(markerProjectionDivisor(TargetPlatform.android, 2.625), 2.625);
+    });
+
+    test('iOS leaves coordinates untouched (already logical)', () {
+      expect(markerProjectionDivisor(TargetPlatform.iOS, 3.0), 1.0);
+    });
+
+    test('non-Android platforms are identity regardless of ratio', () {
+      expect(markerProjectionDivisor(TargetPlatform.macOS, 2.0), 1.0);
+      expect(markerProjectionDivisor(TargetPlatform.linux, 4.0), 1.0);
+    });
+
+    test('a non-positive ratio falls back to identity on Android', () {
+      expect(markerProjectionDivisor(TargetPlatform.android, 0.0), 1.0);
+      expect(markerProjectionDivisor(TargetPlatform.android, -2.0), 1.0);
+    });
+  });
+
+  group('logicalMarkerOffset', () {
+    test('scales a physical-pixel point down to logical pixels', () {
+      final o = logicalMarkerOffset(300, 600, 3.0);
+      expect(o.dx, 100);
+      expect(o.dy, 200);
+    });
+
+    test('divisor of 1 is identity (iOS / non-Android path)', () {
+      final o = logicalMarkerOffset(123.5, 456.5, 1.0);
+      expect(o.dx, 123.5);
+      expect(o.dy, 456.5);
+    });
+
+    test('the origin projects to the origin at any divisor', () {
+      // Matches the reported symptom: markers only lined up at (0,0) because
+      // 0/dpr == 0. Correction must preserve that fixed point.
+      expect(logicalMarkerOffset(0, 0, 3.0), logicalMarkerOffset(0, 0, 1.0));
+    });
+
+    test('non-positive divisor is treated as identity (never blows up)', () {
+      final o = logicalMarkerOffset(300, 600, 0.0);
+      expect(o.dx, 300);
+      expect(o.dy, 600);
+    });
+
+    test('drift grows linearly with distance from origin before correction',
+        () {
+      // Pre-fix, a point 500 logical px from centre landed at 1500 physical
+      // px on a 3x device (the "~4x speed" drift). Post-fix it returns to 500.
+      const dpr = 3.0;
+      final corrected = logicalMarkerOffset(500 * dpr, 500 * dpr, dpr);
+      expect(corrected.dx, 500);
+      expect(corrected.dy, 500);
+    });
+  });
+}


### PR DESCRIPTION
## Bug

Contact pins render in the wrong place on Android and **move as you pan the map** — reported by @supermanisdum and @_mx_ace as a pin appearing in the Indian Ocean, then Italy, then Africa, then the Netherlands while looking around. Only at the screen origin do pin and map agree, which is why it sometimes looked correct.

Fixes #303, #301.

## Changelog

- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Fixed contact pins appearing in the wrong place and drifting as you move the map on Android.

## Root cause

Contact markers are **screen-space overlays**, not map symbols: each contact is projected with `toScreenLocationBatch` and rendered as `Positioned(left: pt.dx - 25, top: pt.dy - 25)`.

On Android maplibre-native returns those points in **physical** pixels, while Flutter's overlay works in **logical** pixels. On a 3x device the marker is drawn ~3x too far from the origin, landing over whatever geography sits under that wrong pixel — and panning changes which geography that is. iOS already returns logical points and is left untouched.

This is why the pin *moves*: a wrong coordinate would pin to one spot and stay there while the map slid under it. A wrong screen position tracks the camera. (See the [discussion on #309](https://github.com/Rezivure/Grid-Mobile/pull/309#issuecomment-5469457581), which was originally mis-filed as the fix for this report.)

## Fix

`markerProjectionDivisor(platform, dpr)` and `logicalMarkerOffset(x, y, divisor)` — Android divides by devicePixelRatio, everything else is identity. A non-positive ratio falls back to 1 so a bad value can never corrupt placement.

Applied at **both** projection sites:
- `map_tab.dart` — the live map
- `location_history_modal.dart` — location history, which runs its own identical uncorrected pipeline. Without this, history markers would keep drifting after this PR merged and the bug would be re-reported against a different screen.

## Tests

Full suite green (498), plus unit coverage for the divisor across platforms and ratios.
