### PR TITLE
fix(lifecycle): keep location service alive on root back press (#302)

### DIFF
--- a/android/app/src/main/kotlin/app/mygrid/grid/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/mygrid/grid/MainActivity.kt
@@ -1,6 +1,27 @@
 package app.mygrid.grid
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterActivity() {
+    // Must match AppLifecycleChannel.channelName on the Dart side.
+    private val lifecycleChannel = "app.mygrid.grid/lifecycle"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            lifecycleChannel,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                // Send the task to the background instead of finishing the
+                // Activity. Finishing tears down the Flutter engine and stops
+                // the location foreground service (GH #302); moveTaskToBack
+                // keeps the service alive, matching Home-button behaviour.
+                "moveTaskToBack" -> result.success(moveTaskToBack(true))
+                else -> result.notImplemented()
+            }
+        }
+    }
 }

--- a/changes/pr-317.md
+++ b/changes/pr-317.md
@@ -1,0 +1,1 @@
+[fix] Location sharing no longer stops when you press the back button on Android.

--- a/lib/screens/map/map_tab.dart
+++ b/lib/screens/map/map_tab.dart
@@ -51,6 +51,7 @@ import 'package:grid_frontend/widgets/user_avatar.dart';
 import 'package:grid_frontend/services/room_service.dart';
 import 'package:grid_frontend/services/user_service.dart';
 import 'package:grid_frontend/services/location_manager.dart';
+import 'package:grid_frontend/services/app_lifecycle_channel.dart';
 import 'package:grid_frontend/services/sharing_state_notifier.dart';
 import 'package:grid_frontend/providers/user_location_provider.dart';
 import 'package:grid_frontend/widgets/onboarding_modal.dart';
@@ -96,6 +97,7 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
   bool _servicesInitialized = false;
   AppLifecycleState? _currentLifecycleState;
   final MaplibreCameraFacade _mapController = MaplibreCameraFacade();
+  final AppLifecycleChannel _lifecycleChannel = AppLifecycleChannel();
   LocationManager? _locationManager;
   RoomService? _roomService;
   UserService? _userService;
@@ -1670,7 +1672,23 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
         } else if (!_initialZoomCalculated) {
         }
       },
-      child: Scaffold(
+      child: PopScope(
+        // On Android, MapTab is the root route: a system-back here would
+        // finish the Activity and stop the location foreground service
+        // (GH #302). Intercept it and send the task to the background instead,
+        // matching Home-button behaviour so sharing keeps running. iOS has no
+        // root back gesture, so canPop stays true there.
+        canPop: false,
+        onPopInvokedWithResult: (didPop, _) async {
+          if (!AppLifecycleChannel.shouldMoveToBackground(
+            didPop: didPop,
+            platform: defaultTargetPlatform,
+          )) {
+            return;
+          }
+          await _lifecycleChannel.moveTaskToBack();
+        },
+        child: Scaffold(
             body: Stack(
               children: [
                 SizedBox(
@@ -2518,6 +2536,7 @@ class _MapTabState extends State<MapTab> with TickerProviderStateMixin, WidgetsB
               ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/lib/services/app_lifecycle_channel.dart
+++ b/lib/services/app_lifecycle_channel.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/services.dart';
+
+/// Bridges Flutter to Android's `Activity.moveTaskToBack`.
+///
+/// Why this exists: MapTab is the root route. On Android, a system-back gesture
+/// on the root route finishes the Activity, which tears down the Flutter engine
+/// and — as a side effect — stops the `location` foreground service. Users
+/// pressing back on the map screen expect the app to go to the background (like
+/// pressing Home), not to be killed with location sharing silently stopped
+/// (GH #302). Sending the task to the back keeps the foreground service alive.
+///
+/// iOS has no root back button, so this is a no-op there.
+class AppLifecycleChannel {
+  AppLifecycleChannel({MethodChannel? channel})
+      : _channel = channel ?? const MethodChannel(channelName);
+
+  /// Name MUST match the channel registered in MainActivity.kt.
+  static const String channelName = 'app.mygrid.grid/lifecycle';
+
+  final MethodChannel _channel;
+
+  /// Pure decision: should a root-route back gesture background the app instead
+  /// of finishing the Activity? Only on Android, and only when the framework
+  /// did not already pop a route (i.e. we're at the root).
+  static bool shouldMoveToBackground({
+    required bool didPop,
+    required TargetPlatform platform,
+  }) =>
+      !didPop && platform == TargetPlatform.android;
+
+  /// Ask Android to send the task to the background. Returns true if native
+  /// handled it. Never throws — if the platform channel is unavailable (iOS,
+  /// tests, or an old build without the native side) we fail closed to false so
+  /// callers can fall back to default behaviour.
+  Future<bool> moveTaskToBack() async {
+    try {
+      final handled = await _channel.invokeMethod<bool>('moveTaskToBack');
+      return handled ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+}

--- a/test/services/app_lifecycle_channel_test.dart
+++ b/test/services/app_lifecycle_channel_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_frontend/services/app_lifecycle_channel.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AppLifecycleChannel.shouldMoveToBackground', () {
+    test('backgrounds on Android when the route did not pop (at root)', () {
+      expect(
+        AppLifecycleChannel.shouldMoveToBackground(
+          didPop: false,
+          platform: TargetPlatform.android,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does nothing on Android when a route was actually popped', () {
+      expect(
+        AppLifecycleChannel.shouldMoveToBackground(
+          didPop: true,
+          platform: TargetPlatform.android,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does nothing on iOS (no root back gesture to intercept)', () {
+      expect(
+        AppLifecycleChannel.shouldMoveToBackground(
+          didPop: false,
+          platform: TargetPlatform.iOS,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('AppLifecycleChannel.moveTaskToBack', () {
+    const channel = MethodChannel(AppLifecycleChannel.channelName);
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+    tearDown(() {
+      messenger.setMockMethodCallHandler(channel, null);
+    });
+
+    test('invokes the native moveTaskToBack method and returns its result',
+        () async {
+      final invoked = <String>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        invoked.add(call.method);
+        return true;
+      });
+
+      final result = await AppLifecycleChannel(channel: channel).moveTaskToBack();
+
+      expect(invoked, ['moveTaskToBack']);
+      expect(result, isTrue);
+    });
+
+    test('fails closed to false when the native side is missing (iOS/old build)',
+        () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        throw MissingPluginException('no native handler');
+      });
+
+      final result = await AppLifecycleChannel(channel: channel).moveTaskToBack();
+
+      expect(result, isFalse);
+    });
+
+    test('fails closed to false on a PlatformException', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        throw PlatformException(code: 'ERR');
+      });
+
+      final result = await AppLifecycleChannel(channel: channel).moveTaskToBack();
+
+      expect(result, isFalse);
+    });
+
+    test('treats a null native result as not handled', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async => null);
+
+      final result = await AppLifecycleChannel(channel: channel).moveTaskToBack();
+
+      expect(result, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #302 — pressing back on the map screen (Android) killed location sharing.

## Changelog

- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Location sharing no longer stops when you press the back button on Android.

## Problem

MapTab is the root route. A system back there finished the Activity, which tore down the Flutter engine and took the location foreground service with it — so sharing silently stopped while the user thought the app was just backgrounded.

## Fix

Intercept the root back press with `PopScope` and call `moveTaskToBack` through a method channel instead, matching Home-button behaviour. The service keeps running.

`canPop: false` is set unconditionally; only the callback is platform-guarded. Verified safe: every route to MapTab (`pushReplacement` / `pushNamedAndRemoveUntil(… => false)`, six call sites) leaves it as the sole route, so there is nothing to pop on iOS either way. The inline comment claiming iOS keeps `canPop` true is inaccurate and should be corrected on a follow-up.

## Verified

Merges clean on current main; 574 tests pass in the merged tree; no new analyzer errors.