### PR TITLE
fix(location): re-broadcast on heartbeat so stationary devices stay fresh (#282)

### DIFF
--- a/changes/pr-318.md
+++ b/changes/pr-318.md
@@ -1,0 +1,1 @@
+[fix] Your location now stays current for your contacts while your phone is sitting still.

--- a/lib/services/location/libre_location_service.dart
+++ b/lib/services/location/libre_location_service.dart
@@ -17,6 +17,7 @@ class LibreLocationService implements LocationService {
 
   StreamSubscription<libre.Position>? _positionSubscription;
   StreamSubscription<libre.Position>? _motionSubscription;
+  StreamSubscription<libre.HeartbeatEvent>? _heartbeatSubscription;
   StreamSubscription<libre.ActivityEvent>? _activitySubscription;
   StreamSubscription<libre.ProviderEvent>? _providerSubscription;
   StreamSubscription<bool>? _powerSaveSubscription;
@@ -89,6 +90,29 @@ class LibreLocationService implements LocationService {
         });
       });
 
+      // Listen for heartbeat pings. When the device is stationary the plugin
+      // pauses GPS and only emits heartbeats, so without this a running-but-
+      // still app never re-broadcasts its location and contacts see it as
+      // frozen until the user reopens the app (#282). The terminated-app path
+      // already handles heartbeats in the headless isolate; this covers the
+      // live Dart stream path.
+      _heartbeatSubscription = libre.LibreLocation.heartbeatStream.listen((event) {
+        final locationUpdate = _mapPositionToLocationUpdate(event.position);
+        _locationStreamController.add(locationUpdate);
+        DebugLogService.instance.log('location', {
+          'latitude': event.position.latitude,
+          'longitude': event.position.longitude,
+          'accuracy': event.position.accuracy,
+          'speed': event.position.speed,
+          'heading': event.position.heading,
+          'altitude': event.position.altitude,
+          'isMoving': event.position.isMoving,
+          'batteryLevel': event.position.battery != null ? (event.position.battery!.level * 100).round() : null,
+          'isCharging': event.position.battery?.isCharging,
+          'source': 'heartbeat',
+        });
+      });
+
       // Listen for activity changes (still/walking/driving/cycling)
       _activitySubscription = libre.LibreLocation.onActivityChange.listen((event) {
         DebugLogService.instance.log('activity_change', {
@@ -150,11 +174,13 @@ class LibreLocationService implements LocationService {
       
       await _positionSubscription?.cancel();
       await _motionSubscription?.cancel();
+      await _heartbeatSubscription?.cancel();
       await _activitySubscription?.cancel();
       await _providerSubscription?.cancel();
       await _powerSaveSubscription?.cancel();
       _positionSubscription = null;
       _motionSubscription = null;
+      _heartbeatSubscription = null;
       _activitySubscription = null;
       _providerSubscription = null;
       _powerSaveSubscription = null;
@@ -283,21 +309,8 @@ class LibreLocationService implements LocationService {
   /// Maps libre_location Position to our platform-agnostic LocationUpdate.
   /// Surfaces battery + charging from `position.battery` so the location
   /// post path can include them in the `m.location` payload.
-  LocationUpdate _mapPositionToLocationUpdate(libre.Position position) {
-    final battery = position.battery;
-    return LocationUpdate(
-      latitude: position.latitude,
-      longitude: position.longitude,
-      accuracy: position.accuracy,
-      speed: position.speed,
-      heading: position.heading,
-      altitude: position.altitude,
-      timestamp: position.timestamp,
-      isMoving: position.isMoving,
-      batteryLevel: battery?.level,
-      isCharging: battery?.isCharging,
-    );
-  }
+  LocationUpdate _mapPositionToLocationUpdate(libre.Position position) =>
+      mapPositionToLocationUpdate(position);
 
   void dispose() {
     if (_isTracking) {
@@ -306,4 +319,24 @@ class LibreLocationService implements LocationService {
     _locationStreamController.close();
     _motionChangeStreamController.close();
   }
+}
+
+/// Maps a libre_location [libre.Position] to a platform-agnostic
+/// [LocationUpdate]. Kept as a top-level pure function so both the position
+/// and heartbeat stream paths share one mapping and it can be unit-tested
+/// without a plugin/platform channel.
+LocationUpdate mapPositionToLocationUpdate(libre.Position position) {
+  final battery = position.battery;
+  return LocationUpdate(
+    latitude: position.latitude,
+    longitude: position.longitude,
+    accuracy: position.accuracy,
+    speed: position.speed,
+    heading: position.heading,
+    altitude: position.altitude,
+    timestamp: position.timestamp,
+    isMoving: position.isMoving,
+    batteryLevel: battery?.level,
+    isCharging: battery?.isCharging,
+  );
 }

--- a/test/services/libre_location_mapping_test.dart
+++ b/test/services/libre_location_mapping_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libre_location/libre_location.dart' as libre;
+import 'package:grid_frontend/services/location/libre_location_service.dart';
+
+/// Unit tests for [mapPositionToLocationUpdate], the pure mapping shared by
+/// the position and heartbeat stream paths in LibreLocationService.
+///
+/// The heartbeat path is what fixes #282 ("location does not periodically
+/// update"): when a device is stationary the plugin pauses GPS and only emits
+/// heartbeat events carrying the last known Position, so the mapping must
+/// faithfully carry every field through for a re-broadcast to be correct.
+void main() {
+  final ts = DateTime.fromMillisecondsSinceEpoch(1720000000000);
+
+  group('mapPositionToLocationUpdate', () {
+    test('carries core coordinate and motion fields through', () {
+      final pos = libre.Position(
+        latitude: 40.7128,
+        longitude: -74.0060,
+        altitude: 12.5,
+        accuracy: 8.0,
+        speed: 1.4,
+        heading: 270.0,
+        timestamp: ts,
+        isMoving: true,
+      );
+
+      final update = mapPositionToLocationUpdate(pos);
+
+      expect(update.latitude, 40.7128);
+      expect(update.longitude, -74.0060);
+      expect(update.altitude, 12.5);
+      expect(update.accuracy, 8.0);
+      expect(update.speed, 1.4);
+      expect(update.heading, 270.0);
+      expect(update.timestamp, ts);
+      expect(update.isMoving, true);
+    });
+
+    test('maps a stationary heartbeat position (isMoving false)', () {
+      // A heartbeat while parked: same last-known fix, not moving. This is
+      // exactly the payload that must still re-broadcast for #282.
+      final pos = libre.Position(
+        latitude: 51.5074,
+        longitude: -0.1278,
+        timestamp: ts,
+        isMoving: false,
+      );
+
+      final update = mapPositionToLocationUpdate(pos);
+
+      expect(update.latitude, 51.5074);
+      expect(update.longitude, -0.1278);
+      expect(update.isMoving, false);
+    });
+
+    test('surfaces battery level and charging state when present', () {
+      final pos = libre.Position(
+        latitude: 1.0,
+        longitude: 2.0,
+        timestamp: ts,
+        battery: const libre.BatteryInfo(level: 0.42, isCharging: true),
+      );
+
+      final update = mapPositionToLocationUpdate(pos);
+
+      expect(update.batteryLevel, 0.42);
+      expect(update.isCharging, true);
+    });
+
+    test('leaves battery fields null when the plugin omits battery', () {
+      final pos = libre.Position(
+        latitude: 1.0,
+        longitude: 2.0,
+        timestamp: ts,
+      );
+
+      final update = mapPositionToLocationUpdate(pos);
+
+      expect(update.batteryLevel, isNull);
+      expect(update.isCharging, isNull);
+    });
+
+    test('a HeartbeatEvent position round-trips through the mapping', () {
+      // Mirrors the live-stream heartbeat path: HeartbeatEvent -> position ->
+      // LocationUpdate for re-broadcast.
+      final event = libre.HeartbeatEvent(
+        position: libre.Position(
+          latitude: 35.6762,
+          longitude: 139.6503,
+          accuracy: 15.0,
+          timestamp: ts,
+          isMoving: false,
+        ),
+      );
+
+      final update = mapPositionToLocationUpdate(event.position);
+
+      expect(update.latitude, 35.6762);
+      expect(update.longitude, 139.6503);
+      expect(update.accuracy, 15.0);
+      expect(update.isMoving, false);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #282 — a stationary phone stops updating its location for contacts.

## Changelog

- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
Your location now stays current for your contacts while your phone is sitting still.

## Problem

When the device is stationary the plugin pauses GPS and emits only heartbeats. Nothing in the live Dart path listened to those, so a running-but-still app never re-broadcast and contacts saw it as frozen until the app was reopened. The terminated-app path already handled heartbeats in the headless isolate; this covers the foreground stream.

## Fix

Subscribe to `LibreLocation.heartbeatStream` and feed it into the same `_locationStreamController` as position updates, so heartbeat fixes go through the normal dispatch throttle.

## Note for reviewers

This re-adds a subscription that `890dd24` removed as "unused". That removal was correct at the time — the old handler only wrote a debug log entry and drove nothing. This one has a real consumer.

It complements `#298` (mode-aware stationary thresholds) rather than duplicating it: #298 decides how often a stationary device *may* post, but that only matters if fixes are still arriving. This is what keeps them arriving.

**Worth a device check before merge.** Whether the plugin already emits positions while stationary on some platforms is not something the unit tests can answer, and if it does there is a duplicate-broadcast (battery) risk. Static verification is clean; real-world confirmation is not.

## Verified

`heartbeatStream` compiles against libre_location ^0.4.1. Merges clean on current main; 574 tests pass in the merged tree; no new analyzer errors.