### PR TITLE
fix(location): force manual Ping past the post throttle (#153)

### DIFF
--- a/changes/pr-319.md
+++ b/changes/pr-319.md
@@ -1,0 +1,1 @@
+[fix] The Ping button now always shares your location, even when you are standing still.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -252,6 +252,9 @@ Future<void> _boot() async {
   final locationDispatch = LocationDispatch(sharingStateNotifier);
   await _tryBootStep(
       'locationDispatch', locationDispatch.start(), const Duration(seconds: 5));
+  // Give LocationManager the same dispatch so a manual "Ping" can force
+  // its fix past the throttle (otherwise stationary pings are dropped).
+  locationManager.locationDispatch = locationDispatch;
 
   // Watches the user's saved home geofence and flips `sharingStateNotifier`
   // on enter/exit. Reads `home_location` + `home_radius` +

--- a/lib/services/location/location_dispatch.dart
+++ b/lib/services/location/location_dispatch.dart
@@ -59,6 +59,12 @@ class LocationDispatch {
   /// resting position immediately.
   bool _justEnteredStill = false;
 
+  /// One-shot override armed by an explicit user action (the manual "Ping"
+  /// button). The next fix posts regardless of distance/interval throttling
+  /// — but pause/incognito still wins, so a ping can never leak a location
+  /// the user has chosen to hide. Drains on the next `shouldPost` call.
+  bool _forceNextPost = false;
+
   // Cruise-mode detection (sustained high-speed driving). Lets the
   // throttle relax once we're confident the user is on the highway —
   // posting every 250m/30s on I-95 for 2 hours is the case that wrecks
@@ -122,6 +128,14 @@ class LocationDispatch {
 
   SharingMode get mode => _mode;
 
+  /// Arms a one-shot bypass of the distance/interval throttle for the next
+  /// fix. Called when the user taps "Ping" — they've explicitly asked to
+  /// broadcast now, so a stationary/recently-posted throttle shouldn't
+  /// silently swallow it. Pause/incognito is still honoured in `shouldPost`.
+  void forceNextPost() {
+    _forceNextPost = true;
+  }
+
   /// Switches the user-facing mode. Persists the choice, swaps the
   /// underlying `libre_location` preset, and rewires the throttle on
   /// the next fix.
@@ -143,11 +157,26 @@ class LocationDispatch {
   /// Returns true if [fix] should be posted to Matrix. Records the post
   /// for distance/interval bookkeeping when true.
   bool shouldPost(LocationUpdate fix) {
-    if (_sharingState.isPaused) return false;
+    if (_sharingState.isPaused) {
+      // Drain any armed ping so it can't fire later when we unpause — a
+      // ping tapped while incognito is discarded, not deferred.
+      _forceNextPost = false;
+      return false;
+    }
 
     final now = DateTime.now();
     final last = _lastPostAt;
     final prev = _lastPostedLocation;
+
+    // Explicit user "Ping" — bypass the throttle exactly once. Drain the
+    // flag first so a queued ping can't stick around and force a second
+    // post. Pause/incognito already short-circuited above, so this can
+    // never override the user's privacy choice.
+    if (_forceNextPost) {
+      _forceNextPost = false;
+      _record(fix, now);
+      return true;
+    }
 
     // First fix in this session → always send.
     if (last == null || prev == null) {

--- a/lib/services/location_manager.dart
+++ b/lib/services/location_manager.dart
@@ -6,6 +6,7 @@ import 'location/location_service.dart';
 import 'location/location_update.dart';
 import 'location/location_service_config.dart';
 import 'location/libre_location_service.dart';
+import 'location/location_dispatch.dart';
 
 /// A simpler location manager relying on the plugin's own stop-detection.
 /// Battery Saver Mode slightly changes the config, otherwise we let
@@ -14,6 +15,12 @@ import 'location/libre_location_service.dart';
 class LocationManager with ChangeNotifier {
   final StreamController<LocationUpdate> _locationStreamController = StreamController.broadcast();
   final LocationService _locationService = LibreLocationService();
+
+  /// Post-throttle that gates which fixes reach Matrix. Settable so
+  /// `main.dart` (which constructs `LocationManager` before
+  /// `LocationDispatch`) can wire it once at boot without a constructor
+  /// refactor. Used to force a manual "Ping" past the throttle.
+  LocationDispatch? locationDispatch;
 
   LocationUpdate? _lastPosition;
   bool _isTracking = false;
@@ -176,13 +183,18 @@ class LocationManager with ChangeNotifier {
   Future<void> grabLocationAndPing() async {
     try {
       final currentPos = await _locationService.getCurrentPosition();
-      
+
       // Always update position and timestamp for manual requests
       _lastPosition = currentPos;
       _lastLocationUpdate = DateTime.now();
+      // A manual ping is an explicit user action: force this fix past the
+      // dispatch throttle so a stationary/recently-posted device still
+      // broadcasts. Without this the fix is emitted but silently dropped
+      // by LocationDispatch.shouldPost(), so contacts never see the ping.
+      locationDispatch?.forceNextPost();
       _locationStreamController.add(currentPos);
       notifyListeners();
-      
+
       print("Manual location ping completed: ${currentPos.latitude}, ${currentPos.longitude}");
     } catch (e) {
       print("Error getting current position: $e");

--- a/test/services/location_dispatch_ping_test.dart
+++ b/test/services/location_dispatch_ping_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:grid_frontend/services/location/location_dispatch.dart';
+import 'package:grid_frontend/services/location/location_update.dart';
+import 'package:grid_frontend/services/sharing_state_notifier.dart';
+
+LocationUpdate _fix({double lat = 40.0, double lng = -74.0}) => LocationUpdate(
+      latitude: lat,
+      longitude: lng,
+      accuracy: 10,
+      speed: 0,
+      heading: 0,
+      altitude: 0,
+      timestamp: DateTime.now(),
+      isMoving: false,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LocationDispatch manual ping (#153)', () {
+    late SharingStateNotifier sharing;
+    late LocationDispatch dispatch;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      sharing = SharingStateNotifier();
+      dispatch = LocationDispatch(sharing);
+    });
+
+    test('forceNextPost overrides the throttle for a stationary re-ping', () {
+      // First fix always posts and records position/time.
+      expect(dispatch.shouldPost(_fix()), isTrue);
+      // Immediate identical fix (no movement, no time) would normally be
+      // throttled away — this is exactly the frozen-ping case.
+      expect(dispatch.shouldPost(_fix()), isFalse);
+
+      // Arming a ping forces the next otherwise-throttled fix through.
+      dispatch.forceNextPost();
+      expect(dispatch.shouldPost(_fix()), isTrue);
+    });
+
+    test('the override is one-shot and drains after a single post', () {
+      expect(dispatch.shouldPost(_fix()), isTrue);
+      dispatch.forceNextPost();
+      expect(dispatch.shouldPost(_fix()), isTrue);
+      // Next stationary fix is throttled again — the flag did not stick.
+      expect(dispatch.shouldPost(_fix()), isFalse);
+    });
+
+    test('a ping never leaks while sharing is paused/incognito', () {
+      expect(dispatch.shouldPost(_fix()), isTrue);
+      sharing.setPausedAtHome(true);
+      dispatch.forceNextPost();
+      // Pause wins over the force flag — privacy is preserved.
+      expect(dispatch.shouldPost(_fix()), isFalse);
+    });
+
+    test('a ping suppressed by pause does not linger into the next unpaused fix',
+        () {
+      expect(dispatch.shouldPost(_fix()), isTrue);
+      sharing.setPausedAtHome(true);
+      dispatch.forceNextPost();
+      expect(dispatch.shouldPost(_fix()), isFalse); // dropped while paused
+      sharing.setPausedAtHome(false);
+      // The force flag was consumed while paused, so a normal stationary
+      // fix is throttled as usual — no delayed surprise broadcast.
+      expect(dispatch.shouldPost(_fix()), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #153 — the manual Ping button does nothing when you haven't moved.

## Changelog

- [ ] `feature`
- [x] `fix`
- [ ] `improvement`
- [ ] `skip`

**Release note:**
The Ping button now always shares your location, even when you are standing still.

## Problem

`grabLocationAndPing()` fetched a fix and emitted it, but `LocationDispatch.shouldPost()` then threw it away on the distance/interval throttle. For a stationary device that is every time — so the user taps Ping, sees no error, and nothing reaches their contacts.

## Fix

`forceNextPost()` arms a one-shot throttle bypass, consumed by the next `shouldPost`. `LocationManager` is handed the dispatch at boot so a manual ping can arm it.

Privacy is preserved: pause/incognito short-circuits *before* the bypass, and the flag is drained while paused, so a ping tapped in incognito is discarded rather than deferred into a surprise broadcast later.

## Ordering

`#311` (invalid-fix guard) has since landed on main. Verified in the merged tree that its validation runs *before* this bypass, so a manual ping still cannot push a NaN/out-of-range fix.

## Verified

Merges clean on current main; 574 tests pass in the merged tree; no new analyzer errors. Four new unit tests cover the one-shot behaviour and the paused/incognito cases.
