### PR TITLE
fix(onboarding): validate the trimmed username the UI actually submits (#196)

### DIFF
--- a/lib/screens/onboarding/server_select_screen.dart
+++ b/lib/screens/onboarding/server_select_screen.dart
@@ -15,6 +15,7 @@ import 'package:grid_frontend/services/in_app_notifier.dart';
 import 'package:grid_frontend/services/passkey_service.dart';
 import 'package:grid_frontend/widgets/passkey_prompt_dialog.dart';
 import 'package:grid_frontend/widgets/turnstile_widget.dart';
+import 'package:grid_frontend/utilities/utils.dart';
 
 class ServerSelectScreen extends StatefulWidget {
   @override
@@ -130,11 +131,11 @@ class _ServerSelectScreenState extends State<ServerSelectScreen> with TickerProv
   }
 
   void _validateUsernameInput() {
-    String username = _usernameController.text;
+    final error = usernameValidationError(_usernameController.text);
 
-    if (username.length < 5) {
+    if (error != null) {
       setState(() {
-        _usernameStatusMessage = 'Username must be at least 5 characters and no special characters or spaces.';
+        _usernameStatusMessage = error;
         _usernameStatusColor = Colors.red;
       });
       return;
@@ -144,22 +145,22 @@ class _ServerSelectScreenState extends State<ServerSelectScreen> with TickerProv
   }
 
   Future<void> _checkUsernameAvailability() async {
-    String username = _usernameController.text;
+    final username = _usernameController.text.trim();
 
-    if (username.isNotEmpty && username.length >= 5) {
-      bool isAvailable = await Provider.of<AuthProvider>(context, listen: false)
-          .checkUsernameAvailability(username);
+    if (usernameValidationError(username) != null) return;
 
-      setState(() {
-        if (isAvailable) {
-          _usernameStatusMessage = 'Username is available';
-          _usernameStatusColor = Colors.green;
-        } else {
-          _usernameStatusMessage = 'Username is not available';
-          _usernameStatusColor = Colors.red;
-        }
-      });
-    }
+    bool isAvailable = await Provider.of<AuthProvider>(context, listen: false)
+        .checkUsernameAvailability(username);
+
+    setState(() {
+      if (isAvailable) {
+        _usernameStatusMessage = 'Username is available';
+        _usernameStatusColor = Colors.green;
+      } else {
+        _usernameStatusMessage = 'Username is not available';
+        _usernameStatusColor = Colors.red;
+      }
+    });
   }
 
   void _animateToNextStep() {

--- a/lib/utilities/utils.dart
+++ b/lib/utilities/utils.dart
@@ -43,6 +43,28 @@ String localpart(String userId) {
   return userId.split(":").first.replaceFirst('@', '');
 }
 
+/// Mirrors the auth server's authoritative rule
+/// (Grid-Auth-Middleware `USERNAME_REGEX = ^[a-zA-Z0-9]{5,}$`, max 50):
+/// letters/digits only, 5-50 chars. Returns a user-facing error message for
+/// [raw], or null when the (trimmed) username is acceptable.
+///
+/// The UI must validate the SAME trimmed value it submits — otherwise a handle
+/// with autofilled/keyboard whitespace can read "available" (green) while the
+/// signup button stays disabled, leaving the user stuck (GH #196).
+String? usernameValidationError(String raw) {
+  final username = raw.trim();
+  if (username.length < 5) {
+    return 'Username must be at least 5 characters and no special characters or spaces.';
+  }
+  if (username.length > 50) {
+    return 'Username must be 50 characters or fewer.';
+  }
+  if (!RegExp(r'^[a-zA-Z0-9]+$').hasMatch(username)) {
+    return 'Username can only contain letters and numbers (no special characters or spaces).';
+  }
+  return null;
+}
+
 /// Converts a `DateTime` into a human-readable "time ago" string.
 String timeAgo(DateTime lastSeen) {
   final now = DateTime.now();

--- a/test/utilities/utils_test.dart
+++ b/test/utilities/utils_test.dart
@@ -49,6 +49,53 @@ void main() {
     });
   });
 
+  group('usernameValidationError', () {
+    test('accepts a valid alphanumeric username', () {
+      expect(usernameValidationError('alice123'), isNull);
+    });
+
+    test('accepts exactly 5 chars', () {
+      expect(usernameValidationError('abcde'), isNull);
+    });
+
+    test('rejects too short', () {
+      expect(usernameValidationError('abcd'),
+          'Username must be at least 5 characters and no special characters or spaces.');
+    });
+
+    test('trims leading/trailing whitespace before length check', () {
+      // Padded to well over 5 raw chars but only 4 real chars -> too short.
+      expect(usernameValidationError('  abcd  '),
+          'Username must be at least 5 characters and no special characters or spaces.');
+    });
+
+    test('accepts a valid username surrounded by whitespace (autofill case)', () {
+      // Core GH #196 bug: keyboard/autofill whitespace must not block signup.
+      expect(usernameValidationError('  alice  '), isNull);
+    });
+
+    test('rejects internal spaces', () {
+      expect(usernameValidationError('al ice'),
+          'Username can only contain letters and numbers (no special characters or spaces).');
+    });
+
+    test('rejects special characters', () {
+      expect(usernameValidationError('alice!'),
+          'Username can only contain letters and numbers (no special characters or spaces).');
+      expect(usernameValidationError('al_ice'), isNotNull);
+      expect(usernameValidationError('al.ice'), isNotNull);
+    });
+
+    test('rejects over 50 chars', () {
+      expect(usernameValidationError('a' * 51),
+          'Username must be 50 characters or fewer.');
+    });
+
+    test('accepts exactly 50 chars', () {
+      expect(usernameValidationError('a' * 50), isNull);
+    });
+  });
+
   group('parseGroupName', () {
     test('extracts group name from standard format', () {
       expect(parseGroupName('Grid Group MyTrip with @alice'), 'MyTrip');


### PR DESCRIPTION
## Problem
GH #196: signup sometimes gets stuck on the username step — the field stays flagged ("5 char minimum / no special characters") even for what looks like a valid handle.

Root cause is a **client-side validation/submit mismatch**, not the backend:
- `_validateUsernameInput()` and `_checkUsernameAvailability()` ran against the **raw** controller text.
- The signup button enable-check and `_signupWithPasskey()` used `.trim()`.

So a handle carrying autofill/keyboard whitespace (common on Xiaomi HyperOS — the reporter's exact platform) could show **"Username is available" (green)** while the button stayed **disabled**, leaving the user stuck with no explanation. Separately, the red error text promised "no special characters or spaces" but nothing actually enforced the charset — invalid handles only failed later at the server.

## Fix
- Add pure `usernameValidationError()` in `utils.dart`, mirroring the auth server's **authoritative** rule (`Grid-Auth-Middleware USERNAME_REGEX = ^[a-zA-Z0-9]{5,}$`, max 50).
- Validate the **trimmed** value in both the inline check and the availability check, so the UI validates exactly what it submits.
- Error messages now match reality (length + charset).

No backend change; no auth-logic change; purely reconciles client validation with the value already sent.

## Tests
- 9 new unit tests for `usernameValidationError` (short, trimmed-short, whitespace-wrapped-valid, internal space, special chars, 50/51 boundaries).
- `flutter test`: **all pass (498)**.
- `flutter analyze` on touched files: no new issues.

Risk: **low** (onboarding validation UX only). Closes #196 client half; SMS half remains deprecated/backend.